### PR TITLE
chore: generate changelog on release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,77 @@
-<a name="8.9.120"></a>
-## 8.9.120 (2018-03-07)
+<a name="9.0.6"></a>
+## [9.0.6](https://github.com/ovh-ux/ovh-manager-dedicated/compare/v9.0.5...v9.0.6) (2018-03-08)
+
+
+### Bug Fixes
+
+* **dedicatedCloud:** add token & action params ([ab9ae86](https://github.com/ovh-ux/ovh-manager-dedicated/commit/ab9ae86))
+
+
+
+<a name="9.0.5"></a>
+## [9.0.5](https://github.com/ovh-ux/ovh-manager-dedicated/compare/v9.0.4...v9.0.5) (2018-03-08)
+
+
+### Bug Fixes
+
+* **account:** fix image path ([36d34ce](https://github.com/ovh-ux/ovh-manager-dedicated/commit/36d34ce))
+* **billing:** fix terminate confirmation ([e71dbce](https://github.com/ovh-ux/ovh-manager-dedicated/commit/e71dbce))
+* **dedicated:** fix user link in operation tab ([1fdad7c](https://github.com/ovh-ux/ovh-manager-dedicated/commit/1fdad7c))
+* **dedicatedcloud:** fix progressbar style for operation in todo ([962827c](https://github.com/ovh-ux/ovh-manager-dedicated/commit/962827c))
+* **dedicatedcloud user:** display error in user edition ([e33de8b](https://github.com/ovh-ux/ovh-manager-dedicated/commit/e33de8b))
+
+
+
+<a name="9.0.4"></a>
+## [9.0.4](https://github.com/ovh-ux/ovh-manager-dedicated/compare/v9.0.3...v9.0.4) (2018-03-08)
+
+
+### Bug Fixes
+
+* update responsive layout ([9ecc102](https://github.com/ovh-ux/ovh-manager-dedicated/commit/9ecc102))
+* **billing:** fix textual close button ([67a249f](https://github.com/ovh-ux/ovh-manager-dedicated/commit/67a249f))
+* **billing:** manager my service - fix actions menu for hosting item ([9f64c75](https://github.com/ovh-ux/ovh-manager-dedicated/commit/9f64c75))
+* **billing services:** change button location for web hosting domain ([dfb4d62](https://github.com/ovh-ux/ovh-manager-dedicated/commit/dfb4d62))
+* **home:** change some links to guides for fr_FR ([3c5e5f1](https://github.com/ovh-ux/ovh-manager-dedicated/commit/3c5e5f1))
+* **home:** fix and remove 2 mores guides ([e1c703c](https://github.com/ovh-ux/ovh-manager-dedicated/commit/e1c703c))
+* **home:** fix guide urls on home page ([1b742f1](https://github.com/ovh-ux/ovh-manager-dedicated/commit/1b742f1))
+
+
+
+<a name="9.0.3"></a>
+## [9.0.3](https://github.com/ovh-ux/ovh-manager-dedicated/compare/v9.0.2...v9.0.3) (2018-03-07)
+
+
+### Bug Fixes
+
+* **dedicated:** fix invalid contacts link ([76e4e69](https://github.com/ovh-ux/ovh-manager-dedicated/commit/76e4e69))
+* **nas order:** fix final order modal ([9dbb566](https://github.com/ovh-ux/ovh-manager-dedicated/commit/9dbb566))
+
+
+
+<a name="9.0.2"></a>
+## [9.0.2](https://github.com/ovh-ux/ovh-manager-dedicated/compare/v9.0.1...v9.0.2) (2018-03-07)
+
+
+### Bug Fixes
+
+* minors fixes (images, invoice ...) ([7d72002](https://github.com/ovh-ux/ovh-manager-dedicated/commit/7d72002))
+* **pcc:** fix vmware vrealize order ([4d8b2cd](https://github.com/ovh-ux/ovh-manager-dedicated/commit/4d8b2cd))
+
+
+
+<a name="9.0.1"></a>
+## [9.0.1](https://github.com/ovh-ux/ovh-manager-dedicated/compare/v9.0.0...v9.0.1) (2018-03-07)
+
+
+### Bug Fixes
+
+* **translations:** fix translations path ([11eefc5](https://github.com/ovh-ux/ovh-manager-dedicated/commit/11eefc5))
+
+
+
+<a name="9.0.0"></a>
+# 9.0.0 (2018-03-07)
 
 
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@ module.exports = function (grunt) {
     "use strict";
 
     function isProd () {
-        return grunt.option("mode") === "prod" || grunt.option("type") !== undefined;
+        return grunt.option("mode") === "prod";
     }
 
     const _ = require("lodash");
@@ -937,16 +937,6 @@ module.exports = function (grunt) {
             }
         },
 
-        // To release
-        bump: {
-            options: {
-                pushTo: "origin",
-                files: ["package.json"],
-                updateConfigs: ["pkg"],
-                commitFiles: ["-a"]
-            }
-        },
-
         ngAnnotate: {
             dist: {
                 files: [{
@@ -1164,21 +1154,4 @@ module.exports = function (grunt) {
         "open",
         "watch"
     ]);
-
-    /*
-     * --type=patch
-     * --type=minor
-     * --type=major
-     */
-    grunt.registerTask("release", "Release", () => {
-        const type = grunt.option("type");
-        if (isProd()) {
-            mode = "prod";
-            grunt.task.run([`bump-only:${type}`, "bump-commit"]);
-        } else {
-            grunt.verbose.or.write(`You try to release in a weird version type [${type}]`).error();
-            grunt.fail.warn("Please try with --type=patch|minor|major");
-        }
-    });
-
 };

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 #### SYSTEM COMMAND ####
 NODE=node
+NPM=npm
 YARN=yarn
 GRUNT=grunt
 GIT=git
@@ -101,7 +102,7 @@ build-us: deps
 	$(TAR) $(DIST_US_TAR) $(DIST_US_DIR)
 
 release: deps
-	$(GRUNT) release --type=$(type)
+	$(NPM) version $(type) -m "Release v%s"
 
 
 ###############

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "update-webdriver": "node node_modules/.bin/webdriver-manager update",
     "commit": "npm-scripts-config commit",
     "commitmsg": "npm-scripts-config commitmsg",
-    "preview-changelog": "npm-scripts-config preview-changelog",
-    "reset-changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0"
+    "version": "npm-scripts-config version",
+    "postversion": "git push && git push --tags",
+    "preview-changelog": "npm-scripts-config preview-changelog"
   },
   "dependencies": {
     "@bower_components/angular-ui-router": "angular-ui/angular-ui-router-bower#^1.0.0",
@@ -107,7 +108,6 @@
     "express-session": "^1.15.1",
     "grunt": "~0.4.5",
     "grunt-babel": "^6.0.0",
-    "grunt-bump": "~0.0.11",
     "grunt-complexity": "~0.1.3",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-concat": "~0.3.0",
@@ -163,7 +163,7 @@
   },
   "config": {
     "commitizen": {
-        "path": "cz-conventional-changelog"
+      "path": "cz-conventional-changelog"
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2939,12 +2939,6 @@ grunt-babel@^6.0.0:
   dependencies:
     babel-core "^6.0.12"
 
-grunt-bump@~0.0.11:
-  version "0.0.17"
-  resolved "https://registry.yarnpkg.com/grunt-bump/-/grunt-bump-0.0.17.tgz#08f6a2a834083068c2a9bd2bc8df9423d98a90a7"
-  dependencies:
-    semver "~2.3.0"
-
 grunt-cli@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/grunt-cli/-/grunt-cli-1.2.0.tgz#562b119ebb069ddb464ace2845501be97b35b6a8"
@@ -5874,10 +5868,6 @@ selenium-webdriver@2.52.0:
 "semver@2 || 3 || 4 || 5", semver@5.5.0, semver@^5.3.0, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
-
-semver@~2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-2.3.2.tgz#b9848f25d6cf36333073ec9ef8856d42f1233e52"
 
 semver@~5.0.1:
   version "5.0.3"


### PR DESCRIPTION
- `grunt-bump` removed since we can use `npm version <type>` directly from our makefile.
- use npm's version script to add release changelog 
- git push commit and tags on npm's postversion script
- `reset-changelog` removed from npm scripts
- changelog regenerated