### PR TITLE
fix(dashboard): hide PCC guides from US customers

### DIFF
--- a/client/app/configuration/configuration.controller.js
+++ b/client/app/configuration/configuration.controller.js
@@ -45,7 +45,8 @@ angular.module("App").controller("ConfigurationCtrl", class ConfigurationCtrl {
                 this.DedicatedCloud.getDescription()
                     .then((ids) => {
                         if (ids && ids.length > 0) {
-                            this.$scope.guide.sections.push("pcc");
+                            // TODO: uncomment when all guides are available on ovhcloud.com.
+                            // this.$scope.guide.sections.push("pcc");
                             deferred.resolve(this.$scope.guide.sections);
                         }
                     })


### PR DESCRIPTION
Guides must be available on ovhcloud.com domain.