### PR TITLE
feat: allow to disable 'open' on grunt serve with --no-open

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,6 +19,12 @@ module.exports = function (grunt) {
     const target = grunt.option("target") || grunt.option("zone") || "EU";
     const targetsAvailable = ["EU", "CA", "US"];
 
+    let doOpen = grunt.option("open");
+    if (doOpen === undefined) {
+        // Default value
+        doOpen = true;
+    }
+
     const filesJsModules = _.map(
         assets[target].modules,
         (module) => {
@@ -1148,11 +1154,15 @@ module.exports = function (grunt) {
         }
     });
 
-    grunt.registerTask("serve", [
+    var serveTasks = [
         "buildDev",
         "env:dev",
         "express:dev",
-        "open",
-        "watch"
-    ]);
+    ];
+    if (doOpen) {
+        serveTasks.push('open');
+    }
+    serveTasks.push('watch');
+
+    grunt.registerTask("serve", serveTasks);
 };


### PR DESCRIPTION
Small change on gruntfile to disable 'open', usefull when node is running on a head-less server