### PR TITLE
fix(sidebar): use User.getUrlOf for url retrieval

### DIFF
--- a/client/app/components/sidebar-menu/sidebar-menu.config.js
+++ b/client/app/components/sidebar-menu/sidebar-menu.config.js
@@ -1,8 +1,8 @@
 angular.module("App")
-    .run(($q, SidebarMenu, Products, User, constants, $translatePartialLoader, $translate, DedicatedCloud, Nas, CdnDomain, featureAvailability) => {
+    .run(($q, SidebarMenu, Products, User, $translatePartialLoader, $translate, DedicatedCloud, Nas, CdnDomain, featureAvailability) => {
 
         function buildSidebarActions () {
-            return User.getUser().then((user) => {
+            return User.getUrlOf("dedicatedOrder").then((dedicatedOrderUrl) => {
                 const actionsMenuOptions = [];
 
                 if (featureAvailability.hasNas()) {
@@ -22,7 +22,7 @@ angular.module("App")
                 actionsMenuOptions.push({
                     title: $translate.instant("navigation_left_dedicatedServers"),
                     icon: "ovh-font ovh-font-server",
-                    href: constants.urls[user.ovhSubsidiary].dedicatedOrder,
+                    href: dedicatedOrderUrl,
                     target: "_blank"
                 });
 


### PR DESCRIPTION
## Fix sidebar initialization

### Description of the Change

use `User.getUrlOf` for url retrieval in sidebar initialization.
Correct the initialization of the sidebar in case where url constant is not defined (the sidebar was not initialized and was empty).

