### PR TITLE
feat(account): add menu for managing API credentials

### DIFF
--- a/client/app/account/user/credentials/delete/user-credentials-delete.controller.js
+++ b/client/app/account/user/credentials/delete/user-credentials-delete.controller.js
@@ -1,0 +1,34 @@
+"use strict";
+angular.module("UserAccount.controllers")
+    .controller("UserAccount.controllers.credentials.delete", class UserAccountCredentialsDeleteController {
+
+        constructor ($scope, UseraccountCredentialsService, Alerter) {
+            this.$scope = $scope;
+            this.UseraccountCredentialsService = UseraccountCredentialsService;
+            this.Alerter = Alerter;
+            this.credential = $scope.currentActionData;
+            this.loader = false;
+        }
+
+        $onInit () {
+            this.$scope.deleteCredential = this.deleteCredential.bind(this);
+        }
+
+        deleteCredential () {
+            this.loader = true;
+
+            this.UseraccountCredentialsService.deleteCredential(this.credential.credentialId)
+                .then(() => {
+                    this.Alerter.success(this.$scope.tr("user_credentials_delete_success_message"), "userCredentials");
+                })
+                .catch((err) => {
+                    this.Alerter.error(`${this.$scope.tr("user_credentials_delete_error_message")} ${_.get(err, "message") || err}`, "userCredentials");
+                })
+                .finally(() => {
+                    this.loader = false;
+                    this.$scope.resetAction();
+                });
+        }
+
+});
+

--- a/client/app/account/user/credentials/delete/user-credentials-delete.html
+++ b/client/app/account/user/credentials/delete/user-credentials-delete.html
@@ -1,0 +1,13 @@
+<div data-ng-controller="UserAccount.controllers.credentials.delete as $ctrl">
+    <div data-wizard
+         data-wizard-on-cancel="resetAction"
+         data-wizard-on-finish="deleteCredential"
+         data-wizard-title="i18n.user_credentials_delete_modal_title">
+
+        <div data-wizard-step>
+            <p class="text-danger" data-ng-bind-html="tr('user_credentials_delete_modal_step1_question', [$ctrl.credential.application.name])"></p>
+        </div>
+
+    </div>
+</div>
+

--- a/client/app/account/user/credentials/user-credentials.controller.js
+++ b/client/app/account/user/credentials/user-credentials.controller.js
@@ -1,0 +1,40 @@
+"use strict";
+angular.module("UserAccount.controllers")
+    .controller("UserAccount.controllers.credentials", class UserAccountCredentialsController {
+
+        constructor ($scope, UseraccountCredentialsService, Alerter) {
+            this.$scope = $scope;
+            this.UseraccountCredentialsService = UseraccountCredentialsService;
+            this.Alerter = Alerter;
+
+            this.$scope.$on("useraccount.credentials.refresh", () => {
+                this.$onInit();
+            });
+        }
+
+        $onInit () {
+            this.credentials = [];
+            this.credentialsLoading = true;
+
+            this.UseraccountCredentialsService.getCredentials()
+                .then((credentials) => {
+                    credentials.forEach((credentialId) => {
+                        this.UseraccountCredentialsService.getCredential(credentialId)
+                            .then((credential) => {
+                                this.UseraccountCredentialsService.getApplication(credentialId)
+                                    .then((application) => {
+                                        credential.application = application;
+                                        this.credentials.push(credential);
+                                    });
+                            });
+                    });
+                })
+                .catch((err) => {
+                    this.Alerter.error(`${this.$scope.tr("user_credentials_error")} ${_.get(err, "message") || err}`, "userCredentials");
+                })
+                .finally(() => {
+                    this.credentialsLoading = false;
+                });
+        }
+    });
+

--- a/client/app/account/user/credentials/user-credentials.html
+++ b/client/app/account/user/credentials/user-credentials.html
@@ -1,0 +1,103 @@
+<div class="module-useraccount-sections-credentials-container"
+     data-ng-controller="UserAccount.controllers.credentials as $ctrl">
+
+    <div class="page-header">
+        <h1 data-i18n-static="user_credentials_title"></h1>
+    </div>
+
+    <div class="tab-content">
+
+        <div data-ovh-alert="userCredentials"></div>
+
+        <!-- CREDENTIALS EXPLAIN -->
+        <div class="alert alert-info"
+             role="alert">
+            <p>
+                <strong data-i18n-static="user_credentials_info"></strong>
+            </p>
+        </div>
+
+        <!-- CREDENTIALS LIST -->
+        <div class="table-responsive">
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th></th>
+                        <th data-i18n-static="user_credentials_name" scope="col"></th>
+                        <th data-i18n-static="user_credentials_desc" scope="col"></th>
+                        <th data-i18n-static="user_credentials_creation_date" scope="col"></th>
+                        <th data-i18n-static="user_credentials_expiration_date" scope="col"></th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody data-ng-show="$ctrl.credentialsLoading">
+                    <tr>
+                        <td colspan="8"
+                            class="text-center">
+                            <oui-spinner data-size="s"></oui-spinner>
+                        </td>
+                    </tr>
+                </tbody>
+                <tbody data-ng-show="$ctrl.credentials.length === 0 && !$ctrl.credentialsLoading">
+                    <tr>
+                        <td colspan="8"
+                            class="text-center font-italic"
+                            data-i18n-static="user_credentials_table_empty">
+                        </td>
+                    </tr>
+                </tbody>
+                <tbody data-ng-show="$ctrl.credentials.length > 0 && !$ctrl.credentialsLoading">
+                    <tr data-ng-repeat-start="credential in $ctrl.credentials track by $index">
+                        <td>
+                            <button class="oui-button oui-button_link" title="{{ tr('user_credentials_show_permissions') }}"
+                                data-ng-if="!credential.isExpanded" data-ng-click="credential.isExpanded = true">
+                                <i class="oui-icon oui-icon-chevron-right"></i>
+                            </button>
+                            <button class="oui-button oui-button_link" title="{{ tr('user_credentials_hide_permissions') }}"
+                                data-ng-if="credential.isExpanded" data-ng-click="credential.isExpanded = false">
+                                <i class="oui-icon oui-icon-chevron-down"></i>
+                            </button>
+                        </td>
+                        <td data-ng-bind="credential.application.name"></td>
+                        <td data-ng-bind="credential.application.description"></td>
+                        <td data-ng-bind="credential.creation | date"></td>
+                        <td data-ng-bind="credential.expiration | date"></td>
+                        <td class="text-right">
+                            <button type="button"
+                                class="oui-button oui-button_secondary"
+                                data-ng-click="setAction('credentials/delete/user-credentials-delete', credential)"
+                                data-i18n-static="user_credentials_delete">
+                            </button>
+                        </td>
+                    </tr>
+                    <tr data-ng-show="credential.isExpanded" data-ng-repeat-end>
+                        <td colspan="3">
+                        <table class="table table-hover">
+                            <thead>
+                                <tr>
+                                    <th data-i18n-static="user_credentials_permissions_method" scope="col"></th>
+                                    <th data-i18n-static="user_credentials_permissions_path" scope="col"></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr data-ng-repeat="rule in credential.rules track by $index">
+                                    <td>
+                                        <span class="label ng-binding" data-ng-class="{
+                                            'label-danger': rule.method == 'DELETE',
+                                            'label-success': rule.method == 'POST',
+                                            'label-info': rule.method == 'GET',
+                                            'label-warning': rule.method == 'PUT'
+                                            }" data-ng-bind="rule.method"></span>
+                                    </td>
+                                    <td data-ng-bind="rule.path"></td>
+                                </tr>                                
+                            </tbody>
+                        </table>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+

--- a/client/app/account/user/credentials/user-credentials.service.js
+++ b/client/app/account/user/credentials/user-credentials.service.js
@@ -1,0 +1,43 @@
+angular.module("UserAccount.services").service("UseraccountCredentialsService", [
+    "OvhHttp",
+    function (OvhHttp) {
+        "use strict";
+
+        const self = this;
+
+        self.getCredentials = function () {
+            return OvhHttp.get("/me/api/credential", {
+                rootPath: "apiv6"
+            });
+        };
+
+        self.getCredential = function (credentialId) {
+            return OvhHttp.get("/me/api/credential/{credentialId}", {
+                rootPath: "apiv6",
+                urlParams: {
+                    credentialId
+                }
+            });
+        };
+
+        self.getApplication = function (credentialId) {
+            return OvhHttp.get("/me/api/credential/{credentialId}/application", {
+                rootPath: "apiv6",
+                urlParams: {
+                    credentialId
+                }
+            });
+        };
+
+        self.deleteCredential = function (credentialId) {
+            return OvhHttp.delete("/me/api/credential/{credentialId}", {
+                rootPath: "apiv6",
+                urlParams: {
+                    credentialId
+                },
+                broadcast: "useraccount.credentials.refresh"
+            });
+        };
+    }
+]);
+

--- a/client/app/account/user/user.module.js
+++ b/client/app/account/user/user.module.js
@@ -71,6 +71,14 @@ angular
                 controller: "UserAccount.controllers.Infos"
             });
 
+            $stateProvider.state("app.account.useraccount.credentials", {
+                url: "/credentials",
+                templateUrl: `${baseUrl}credentials/user-credentials.html`,
+                controller: "UserAccount.controllers.credentials",
+                controllerAs: "ctrl"
+            });
+
+
             if (target === "EU" || target === "CA") {
 
                 $stateProvider.state("app.account.useraccount.emails", {

--- a/client/app/components/sidebar-menu/account/sidebar-menu-account.config.js
+++ b/client/app/components/sidebar-menu/account/sidebar-menu-account.config.js
@@ -39,6 +39,11 @@ angular.module("App").run(($q, $translatePartialLoader, $translate, SidebarMenu,
             state: "app.account.useraccount.ssh"
         }, myAccountMenu);
 
+        SidebarMenu.addMenuItem({
+            title: $translate.instant("menu_credentials"),
+            state: "app.account.useraccount.credentials"
+        }, myAccountMenu);
+
         if (constants.target === "EU" || constants.target === "CA") {
             SidebarMenu.addMenuItem({
                 title: $translate.instant("menu_advanced"),

--- a/client/app/components/sidebar-menu/account/translations/Messages_fr_FR.xml
+++ b/client/app/components/sidebar-menu/account/translations/Messages_fr_FR.xml
@@ -26,6 +26,7 @@
    <translation id="menu_subscriptions" qtlid="144708">Mes abonnements</translation>
    <translation id="menu_ssh" qtlid="165897">Mes clés SSH</translation>
    <translation id="menu_infos" qtlid="405499">Mon profil</translation>
+   <translation id="menu_credentials">Applications</translation>
    <translation id="menu_advanced" qtlid="39958">Paramètres avancés</translation>
    <translation id="menu_services" qtlid="229658">Mes services</translation>
    <translation id="menu_account_title" qtlid="157642">Mon compte</translation>

--- a/client/app/resources/i18n/useraccount/Messages_fr_FR.xml
+++ b/client/app/resources/i18n/useraccount/Messages_fr_FR.xml
@@ -152,6 +152,24 @@
    <translation id="user_agreement_details_success" qtlid="410598">Votre contrat a bien été validé.</translation>
    <translation id="user_agreement_details_error" qtlid="410611">Une erreur s'est produite lors de l'acceptation de votre contrat.</translation>
 
+   <translation id="user_credentials_title">Applications autorisées</translation>
+   <translation id="user_credentials_info">Les applications ci-dessous ont accès à votre espace client.</translation>
+   <translation id="user_credentials_error">Une erreur est survenue lors du chargement de la liste de vos applications.</translation>
+   <translation id="user_credentials_table_empty">Aucune application</translation>
+   <translation id="user_credentials_name">Nom</translation>
+   <translation id="user_credentials_desc">Description</translation>
+   <translation id="user_credentials_creation_date">Date de création</translation>
+   <translation id="user_credentials_expiration_date">Date d'expiration</translation>
+   <translation id="user_credentials_show_permissions">Afficher les permissions</translation>
+   <translation id="user_credentials_hide_permissions">Masquer</translation>
+   <translation id="user_credentials_permissions_method">Méthode</translation>
+   <translation id="user_credentials_permissions_path">Chemin</translation>
+   <translation id="user_credentials_delete">Révoquer</translation>
+   <translation id="user_credentials_delete_modal_title">Supprimer une application</translation>
+   <translation id="user_credentials_delete_modal_step1_question">Êtes-vous sûr de vouloir supprimer l'application <strong>{0}</strong> ?</translation>
+   <translation id="user_credentials_delete_success_message">L'application a été supprimée.</translation>
+   <translation id="user_credentials_delete_error_message">Une erreur s'est produite lors de la suppression de l'application.</translation>
+
    <translation id="user_ipRestrictions_title" qtlid="225486">Restriction d'accès par IP</translation>
    <translation id="user_ipRestrictions_activate" qtlid="76734">Activer</translation>
    <translation id="user_ipRestrictions_default_rule" qtlid="229710">Règle par défaut</translation>


### PR DESCRIPTION
## feat(account): add menu for managing API credentials

### Description of the Change

The goal of this PR is to add a menu under "My account" to manage API credentials:
- List application credentials that the user has authorized and their creation/expiration date
- Show permissions 
- Revoke credentials

![manager-creds](https://user-images.githubusercontent.com/2123633/38457361-f1f9f97c-3a7e-11e8-8ab6-7e95d9316c02.png)

![manager-creds-perms](https://user-images.githubusercontent.com/2123633/38457365-f5dd0ade-3a7e-11e8-84ca-dc343873662c.png)

### Benefits

Users can manage their API credentials directly through the Manager.

### Possible Drawbacks

I don't see any

### Applicable Issues

* Credentials for the Manager itself are also displayed, couldn't find a proper way to filter them out (_i.e._ not just `if app.name == 'ManagerV6'`)
* The sub-table for displaying permissions is not yet very attractive

I'm not a front developer at all so I'd be glad to make further modifications if necessary, feedback very welcomed.
