### PR TITLE
fix(me-alerts): fix bad links to billing statements

### DIFF
--- a/client/app/components/user/user-alert.controller.js
+++ b/client/app/components/user/user-alert.controller.js
@@ -15,9 +15,9 @@ angular.module("App").controller("UserAlertCtrl", [
                         switch (alert.id) {
                         case "DEBTACCOUNT_DEBT":
                             if (_.get(alert, "data.debtAccount.unmaturedAmount.value", 0) > 0) {
-                                messages.push(translator.tr("me_alerts_DEBTACCOUNT_DEBT_WITH_UNMATURED_AMOUNT", [_.get(alert, "data.debtAccount.dueAmount.text"), _.get(alert, "data.debtAccount.unmaturedAmount.text")]));
+                                messages.push(translator.tr("me_alerts_DEBTACCOUNT_DEBT_WITH_UNMATURED_AMOUNT", [_.get(alert, "data.debtAccount.dueAmount.text"), _.get(alert, "data.debtAccount.unmaturedAmount.text"), "#/billing/history"]));
                             } else {
-                                messages.push(translator.tr("me_alerts_DEBTACCOUNT_DEBT", [_.get(alert, "data.debtAccount.dueAmount.text")]));
+                                messages.push(translator.tr("me_alerts_DEBTACCOUNT_DEBT", [_.get(alert, "data.debtAccount.dueAmount.text"), "#/billing/history"]));
                             }
                             break;
                         case "OVHACCOUNT_DEBT":

--- a/client/app/resources/i18n/core/Messages_fr_FR.xml
+++ b/client/app/resources/i18n/core/Messages_fr_FR.xml
@@ -538,8 +538,8 @@
    <translation id="me_alerts_PAYMENTMEAN_PAYPAL_TOOMANYFAILURES" qtlid="343967">Vous avez <strong>{0}</strong> compte(s) PayPal en erreur. Rendez-vous dans <a href="#/billing/mean" class="alert-link">la section facturation</a> pour effectuer les vérifications et/ou enregistrer un nouveau moyen de paiement.</translation>
 
    <translation id="me_alerts_OVHACCOUNT_DEBT" qtlid="374958">Votre compte prépayé est débiteur de <strong>{0}</strong> au {{ '{1}' | date:'medium'}}. Rendez-vous dans <a href="#/billing/ovhaccount" class="alert-link">la section facturation</a> pour régulariser la situation.</translation>
-   <translation id="me_alerts_DEBTACCOUNT_DEBT_WITH_UNMATURED_AMOUNT" qtlid="369545">Vous avez une dette de <strong>{0}</strong> (dont un montant de {1} non échu). Rendez-vous dans <a href="#/billing/statements" class="alert-link">la section facturation</a> pour régulariser la situation.</translation>
-   <translation id="me_alerts_DEBTACCOUNT_DEBT" qtlid="343993">Vous avez une dette de <strong>{0}</strong>. Rendez-vous dans <a href="#/billing/statements" class="alert-link">la section facturation</a> pour régulariser la situation.</translation>
+   <translation id="me_alerts_DEBTACCOUNT_DEBT_WITH_UNMATURED_AMOUNT" qtlid="369545">Vous avez une dette de <strong>{0}</strong> (dont un montant de {1} non échu). Rendez-vous dans <a href="{2}" class="alert-link">la section facturation</a> pour régulariser la situation.</translation>
+   <translation id="me_alerts_DEBTACCOUNT_DEBT" qtlid="343993">Vous avez une dette de <strong>{0}</strong>. Rendez-vous dans <a href="{1}" class="alert-link">la section facturation</a> pour régulariser la situation.</translation>
 
    <translation id="me_alerts_OVHACCOUNT_ALERTTHRESHOLD" qtlid="383919">Votre compte prépayé a atteint le seuil que vous avez défini. Rendez-vous dans <a href="#/billing/ovhaccount" class="alert-link">la section facturation</a> pour plus d'informations.</translation>
 


### PR DESCRIPTION
Fix bad links from me-alerts that point to billing/statements section.

- [ ] change qtlid in translator
- [ ] retrieve trads

Linked to:
* ovh-ux/ovh-manager-cloud#666
* ovh-ux/ovh-manager-telecom#689
* ovh-ux/ovh-manager-web#389