### PR TITLE
refactor(account user): flattened to single module

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -619,15 +619,10 @@ module.exports = function (grunt) {
                     deps: [
                         "ja.qr",
                         "ovh-utils-angular",
-                        "UserAccount.services",
-                        "UserAccount.controllers",
-                        "UserAccount.directives",
-                        "UserAccount.filters",
                         "ovhSignupApp"
                     ]
                 },
                 constants: {
-                    "UserAccount.conf.BASE_URL": "account/user/",
                     "UserAccount.constants": {
                         aapiRootPath: "<%= aapiPath %>",
                         swsProxyRootPath: "<%= swsProxyPath %>",
@@ -770,15 +765,10 @@ module.exports = function (grunt) {
                     deps: [
                         "ja.qr",
                         "ovh-utils-angular",
-                        "UserAccount.services",
-                        "UserAccount.controllers",
-                        "UserAccount.directives",
-                        "UserAccount.filters",
                         "ovhSignupApp"
                     ]
                 },
                 constants: {
-                    "UserAccount.conf.BASE_URL": "account/user/",
                     "UserAccount.constants": {
                         aapiRootPath: "<%= aapiPath %>",
                         swsProxyRootPath: "<%= swsProxyPath %>",

--- a/client/app/account/user/advanced/user-advanced.controller.js
+++ b/client/app/account/user/advanced/user-advanced.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.advanced", [
+angular.module("UserAccount").controller("UserAccount.controllers.advanced", [
     "UserAccount.services.Infos",
     "Alerter",
     "$translate",

--- a/client/app/account/user/agreements/details/user-agreements-details.controller.js
+++ b/client/app/account/user/agreements/details/user-agreements-details.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.agreements.details", [
+angular.module("UserAccount").controller("UserAccount.controllers.agreements.details", [
     "$stateParams",
     "$q",
     "$log",

--- a/client/app/account/user/agreements/user-agreements.controller.js
+++ b/client/app/account/user/agreements/user-agreements.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.agreements", [
+angular.module("UserAccount").controller("UserAccount.controllers.agreements", [
     "$scope",
     "$translate",
     "UserAccount.services.agreements",

--- a/client/app/account/user/agreements/user-agreements.service.js
+++ b/client/app/account/user/agreements/user-agreements.service.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.services").service("UserAccount.services.agreements", [
+angular.module("UserAccount").service("UserAccount.services.agreements", [
     "$http",
     "$q",
     "UserAccount.constants",

--- a/client/app/account/user/common/validator.service.js
+++ b/client/app/account/user/common/validator.service.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-angular.module("UserAccount.services").service("UserValidator", [
+angular.module("UserAccount").service("UserValidator", [
     function () {
         "use strict";
 

--- a/client/app/account/user/components/directives/checkboxSwitch/checkboxSwitch.js
+++ b/client/app/account/user/components/directives/checkboxSwitch/checkboxSwitch.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-shadow */
-angular.module("UserAccount.directives").directive("checkboxSwitch", [
+angular.module("UserAccount").directive("checkboxSwitch", [
     "$timeout",
     function ($timeout) {
         "use strict";

--- a/client/app/account/user/components/directives/directives.module.js
+++ b/client/app/account/user/components/directives/directives.module.js
@@ -1,1 +1,0 @@
-angular.module("UserAccount.directives", []);

--- a/client/app/account/user/components/directives/sshkeySwitch/sshkeySwitch.js
+++ b/client/app/account/user/components/directives/sshkeySwitch/sshkeySwitch.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.directives").directive("sshkeySwitch", [
+angular.module("UserAccount").directive("sshkeySwitch", [
     "sshkey-regex",
     function (SSHKEY_REGEX) {
         "use strict";

--- a/client/app/account/user/components/filters/filters.js
+++ b/client/app/account/user/components/filters/filters.js
@@ -1,1 +1,0 @@
-angular.module("UserAccount.filters", []);

--- a/client/app/account/user/components/filters/sshkeyMin/sshkeyMin.js
+++ b/client/app/account/user/components/filters/sshkeyMin/sshkeyMin.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.filters").filter("sshkeyMin", [
+angular.module("UserAccount").filter("sshkeyMin", [
     "sshkey-regex",
     function (SSHKEY_REGEX) {
         "use strict";

--- a/client/app/account/user/components/newAccountForm/field/new-account-form-field-component.js
+++ b/client/app/account/user/components/newAccountForm/field/new-account-form-field-component.js
@@ -8,18 +8,17 @@ angular.module("ovhSignupApp").component("newAccountFormField", {
     },
     template: '<div data-ng-include="getTemplateUrl()"></div>',
     controller: [
-        "$scope",
         "$filter",
-        "$translate",
         "$q",
+        "$scope",
         "$timeout",
+        "$translate",
         "NewAccountFormConfig",
-        "UserAccount.conf.BASE_URL",
 
-        function ($scope, $filter, $translate, $q, $timeout, NewAccountFormConfig, BASE_URL) {
+        function ($filter, $q, $scope, $timeout, $translate, NewAccountFormConfig) {
             "use strict";
 
-            $scope.getTemplateUrl = () => `${BASE_URL}components/newAccountForm/field/new-account-form-field-component.html`;
+            $scope.getTemplateUrl = () => "account/user/components/newAccountForm/field/new-account-form-field-component.html";
 
             this.$onInit = function () {
                 // unique field identifier

--- a/client/app/account/user/components/newAccountForm/new-account-form-component.js
+++ b/client/app/account/user/components/newAccountForm/new-account-form-component.js
@@ -15,13 +15,12 @@ angular.module("ovhSignupApp").component("newAccountForm", {
         "$timeout",
         "NewAccountFormConfig",
         "Alerter",
-        "UserAccount.conf.BASE_URL",
         "UserAccount.constants",
         "UserAccount.services.Infos",
         "$translate",
         "constants",
 
-        function ($scope, $q, $location, $http, $httpParamSerializerJQLike, $timeout, NewAccountFormConfig, Alerter, BASE_URL, UserAccountConstants, UserAccountServiceInfos, $translate, constants) {
+        function ($scope, $q, $location, $http, $httpParamSerializerJQLike, $timeout, NewAccountFormConfig, Alerter, UserAccountConstants, UserAccountServiceInfos, $translate, constants) {
             "use strict";
 
             this.isLoading = false; // true when fetching data from api
@@ -33,7 +32,7 @@ angular.module("ovhSignupApp").component("newAccountForm", {
             this.isSubmitting = false;
             const CONSENT_MARKETING_EMAIL_NAME = "consent-marketing-email";
 
-            $scope.getTemplateUrl = () => `${BASE_URL}components/newAccountForm/new-account-form-component.html`;
+            $scope.getTemplateUrl = () => "account/user/components/newAccountForm/new-account-form-component.html";
 
             this.$onInit = () => {
                 // backup of original model

--- a/client/app/account/user/contacts/request/change/user-contacts-request-change.controller.js
+++ b/client/app/account/user/contacts/request/change/user-contacts-request-change.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.contacts.request", [
+angular.module("UserAccount").controller("UserAccount.controllers.contacts.request", [
     "$scope",
     "$stateParams",
     "$translate",

--- a/client/app/account/user/contacts/request/received/user-contacts-request-received.controller.js
+++ b/client/app/account/user/contacts/request/received/user-contacts-request-received.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.contacts.requestsReceived", [
+angular.module("UserAccount").controller("UserAccount.controllers.contacts.requestsReceived", [
     "$scope",
     "$translate",
     "UserAccount.services.Contacts",

--- a/client/app/account/user/contacts/request/send/user-contacts-request-send.controller.js
+++ b/client/app/account/user/contacts/request/send/user-contacts-request-send.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.contacts.requestsSend", [
+angular.module("UserAccount").controller("UserAccount.controllers.contacts.requestsSend", [
     "$scope",
     "$translate",
     "UserAccount.services.Contacts",

--- a/client/app/account/user/contacts/request/user-contacts-request.controller.js
+++ b/client/app/account/user/contacts/request/user-contacts-request.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.contacts.requests", [
+angular.module("UserAccount").controller("UserAccount.controllers.contacts.requests", [
     "$scope",
     "UserAccount.services.Contacts",
     "Alerter",

--- a/client/app/account/user/contacts/service/user-contacts-service.controller.js
+++ b/client/app/account/user/contacts/service/user-contacts-service.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.contactServices", [
+angular.module("UserAccount").controller("UserAccount.controllers.contactServices", [
     "$scope",
     "UserAccount.services.Contacts",
     "Alerter",

--- a/client/app/account/user/contacts/update/user-contacts-update.controller.js
+++ b/client/app/account/user/contacts/update/user-contacts-update.controller.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.update", [
+angular.module("UserAccount").controller("UserAccount.controllers.update", [
     "UserAccount.services.Contacts",
     "$scope",
     "$stateParams",

--- a/client/app/account/user/contacts/user-contacts.controller.js
+++ b/client/app/account/user/contacts/user-contacts.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers")
+angular.module("UserAccount")
     .controller("UserAccount.controllers.contactCtrl", class AccountUserContactsController {
         constructor ($location, $q, $scope, AccountCreationURLS, Alerter, OvhApiMe) {
             this.$location = $location;

--- a/client/app/account/user/contacts/user-contacts.service.js
+++ b/client/app/account/user/contacts/user-contacts.service.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.services").service("UserAccount.services.Contacts", function (OvhHttp, constants, Poller, $rootScope) {
+angular.module("UserAccount").service("UserAccount.services.Contacts", function (OvhHttp, constants, Poller, $rootScope) {
     "use strict";
 
     const self = this;

--- a/client/app/account/user/controllers.module.js
+++ b/client/app/account/user/controllers.module.js
@@ -1,1 +1,0 @@
-angular.module("UserAccount.controllers", []);

--- a/client/app/account/user/emails/details/user-emails-details.controller.js
+++ b/client/app/account/user/emails/details/user-emails-details.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.emails.details", [
+angular.module("UserAccount").controller("UserAccount.controllers.emails.details", [
     "$scope",
     "$stateParams",
     "UserAccount.services.emails",

--- a/client/app/account/user/emails/user-emails.controller.js
+++ b/client/app/account/user/emails/user-emails.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.emails", [
+angular.module("UserAccount").controller("UserAccount.controllers.emails", [
     "$q",
     "$location",
     "$scope",

--- a/client/app/account/user/emails/user-emails.service.js
+++ b/client/app/account/user/emails/user-emails.service.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.services").service("UserAccount.services.emails", [
+angular.module("UserAccount").service("UserAccount.services.emails", [
     "constants",
     "OvhHttp",
     function (constants, OvhHttp) {

--- a/client/app/account/user/infos/user-infos.controller.js
+++ b/client/app/account/user/infos/user-infos.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.Infos", [
+angular.module("UserAccount").controller("UserAccount.controllers.Infos", [
     "$scope",
     "$q",
     "$location",

--- a/client/app/account/user/infos/user-infos.service.js
+++ b/client/app/account/user/infos/user-infos.service.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.services").service("UserAccount.services.Infos", [
+angular.module("UserAccount").service("UserAccount.services.Infos", [
     "$http",
     "$q",
     "UserAccount.constants",

--- a/client/app/account/user/ip/restriction/add/user-ip-restriction-add.controller.js
+++ b/client/app/account/user/ip/restriction/add/user-ip-restriction-add.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.ipRestrictions.add", [
+angular.module("UserAccount").controller("UserAccount.controllers.ipRestrictions.add", [
     "$rootScope",
     "$scope",
     "$translate",

--- a/client/app/account/user/ip/restriction/delete/user-ip-restriction-delete.controller.js
+++ b/client/app/account/user/ip/restriction/delete/user-ip-restriction-delete.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.ipRestrictions.delete", [
+angular.module("UserAccount").controller("UserAccount.controllers.ipRestrictions.delete", [
     "$rootScope",
     "$scope",
     "$translate",

--- a/client/app/account/user/ip/restriction/user-ip-restriction.controller.js
+++ b/client/app/account/user/ip/restriction/user-ip-restriction.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.ipRestrictions", [
+angular.module("UserAccount").controller("UserAccount.controllers.ipRestrictions", [
     "$rootScope",
     "$scope",
     "$translate",

--- a/client/app/account/user/ip/restriction/user-ip-restriction.service.js
+++ b/client/app/account/user/ip/restriction/user-ip-restriction.service.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.services").service("UserAccount.services.ipRestrictions", [
+angular.module("UserAccount").service("UserAccount.services.ipRestrictions", [
     "$http",
     "$q",
     function ($http, $q) {

--- a/client/app/account/user/password/user-password.controller.js
+++ b/client/app/account/user/password/user-password.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.doubleAuth.password", [
+angular.module("UserAccount").controller("UserAccount.controllers.doubleAuth.password", [
     "$scope",
     "$translate",
     "UserAccount.services.Infos",

--- a/client/app/account/user/security/2fa/user-security-2fa.controller.js
+++ b/client/app/account/user/security/2fa/user-security-2fa.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.doubleAuth.2fa.enable", [
+angular.module("UserAccount").controller("UserAccount.controllers.doubleAuth.2fa.enable", [
     "$rootScope",
     "$scope",
     "$q",

--- a/client/app/account/user/security/backupCode/delete/user-security-backupCode.controller.js
+++ b/client/app/account/user/security/backupCode/delete/user-security-backupCode.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.doubleAuth.backupCode.delete", [
+angular.module("UserAccount").controller("UserAccount.controllers.doubleAuth.backupCode.delete", [
     "$rootScope",
     "$scope",
     "$translate",

--- a/client/app/account/user/security/backupCode/manage/user-security-backupCode-manage.controller.js
+++ b/client/app/account/user/security/backupCode/manage/user-security-backupCode-manage.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.doubleAuth.backupCode.manage", [
+angular.module("UserAccount").controller("UserAccount.controllers.doubleAuth.backupCode.manage", [
     "$rootScope",
     "$scope",
     "$translate",

--- a/client/app/account/user/security/backupCode/user-security-backupCode.controller.js
+++ b/client/app/account/user/security/backupCode/user-security-backupCode.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.doubleAuth.backupCode", [
+angular.module("UserAccount").controller("UserAccount.controllers.doubleAuth.backupCode", [
     "$scope",
     "$translate",
     "UserAccount.services.doubleAuth.backupCode",

--- a/client/app/account/user/security/backupCode/user-security-backupCode.service.js
+++ b/client/app/account/user/security/backupCode/user-security-backupCode.service.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.services").service("UserAccount.services.doubleAuth.backupCode", function (OvhHttp) {
+angular.module("UserAccount").service("UserAccount.services.doubleAuth.backupCode", function (OvhHttp) {
     "use strict";
 
     /**

--- a/client/app/account/user/security/sms/add/user-security-sms-add.controller.js
+++ b/client/app/account/user/security/sms/add/user-security-sms-add.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.doubleAuth.sms.add", [
+angular.module("UserAccount").controller("UserAccount.controllers.doubleAuth.sms.add", [
     "$rootScope",
     "$scope",
     "$translate",

--- a/client/app/account/user/security/sms/delete/user-security-sms-delete.controller.js
+++ b/client/app/account/user/security/sms/delete/user-security-sms-delete.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.doubleAuth.sms.delete", [
+angular.module("UserAccount").controller("UserAccount.controllers.doubleAuth.sms.delete", [
     "$rootScope",
     "$scope",
     "$q",

--- a/client/app/account/user/security/sms/edit/user-security-sms-edit.controller.js
+++ b/client/app/account/user/security/sms/edit/user-security-sms-edit.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.doubleAuth.sms.edit", [
+angular.module("UserAccount").controller("UserAccount.controllers.doubleAuth.sms.edit", [
     "$rootScope",
     "$scope",
     "$translate",

--- a/client/app/account/user/security/sms/user-security-sms.controller.js
+++ b/client/app/account/user/security/sms/user-security-sms.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.doubleAuth.sms", [
+angular.module("UserAccount").controller("UserAccount.controllers.doubleAuth.sms", [
     "$scope",
     "$q",
     "$translate",

--- a/client/app/account/user/security/sms/user-security-sms.service.js
+++ b/client/app/account/user/security/sms/user-security-sms.service.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.services").service("UserAccount.services.doubleAuth.sms", function ($q, OvhHttp, featureAvailability) {
+angular.module("UserAccount").service("UserAccount.services.doubleAuth.sms", function ($q, OvhHttp, featureAvailability) {
     "use strict";
 
     /**

--- a/client/app/account/user/security/totp/add/user-security-totp-add.controller.js
+++ b/client/app/account/user/security/totp/add/user-security-totp-add.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.doubleAuth.totp.add", [
+angular.module("UserAccount").controller("UserAccount.controllers.doubleAuth.totp.add", [
     "$rootScope",
     "$scope",
     "$q",

--- a/client/app/account/user/security/totp/delete/user-security-totp-delete.controller.js
+++ b/client/app/account/user/security/totp/delete/user-security-totp-delete.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.doubleAuth.totp.delete", [
+angular.module("UserAccount").controller("UserAccount.controllers.doubleAuth.totp.delete", [
     "$rootScope",
     "$scope",
     "$q",

--- a/client/app/account/user/security/totp/edit/user-security-totp-edit.controller.js
+++ b/client/app/account/user/security/totp/edit/user-security-totp-edit.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.doubleAuth.totp.edit", [
+angular.module("UserAccount").controller("UserAccount.controllers.doubleAuth.totp.edit", [
     "$rootScope",
     "$scope",
     "$translate",

--- a/client/app/account/user/security/totp/user-security-totp.controller.js
+++ b/client/app/account/user/security/totp/user-security-totp.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.doubleAuth.totp", [
+angular.module("UserAccount").controller("UserAccount.controllers.doubleAuth.totp", [
     "$scope",
     "$q",
     "$translate",

--- a/client/app/account/user/security/totp/user-security-totp.service.js
+++ b/client/app/account/user/security/totp/user-security-totp.service.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.services").service("UserAccount.services.doubleAuth.totp", [
+angular.module("UserAccount").service("UserAccount.services.doubleAuth.totp", [
     "OvhHttp",
     function (OvhHttp) {
         "use strict";

--- a/client/app/account/user/security/u2f/add/user-security-u2f-add.controller.js
+++ b/client/app/account/user/security/u2f/add/user-security-u2f-add.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.doubleAuth.u2f.add", [
+angular.module("UserAccount").controller("UserAccount.controllers.doubleAuth.u2f.add", [
     "$rootScope",
     "$scope",
     "$translate",

--- a/client/app/account/user/security/u2f/delete/user-security-u2f-delete.controller.js
+++ b/client/app/account/user/security/u2f/delete/user-security-u2f-delete.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.doubleAuth.u2f.delete", [
+angular.module("UserAccount").controller("UserAccount.controllers.doubleAuth.u2f.delete", [
     "$rootScope",
     "$scope",
     "$q",

--- a/client/app/account/user/security/u2f/edit/user-security-u2f-edit.controller.js
+++ b/client/app/account/user/security/u2f/edit/user-security-u2f-edit.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.doubleAuth.u2f.edit", [
+angular.module("UserAccount").controller("UserAccount.controllers.doubleAuth.u2f.edit", [
     "$rootScope",
     "$scope",
     "$q",

--- a/client/app/account/user/security/u2f/user-security-u2f.controller.js
+++ b/client/app/account/user/security/u2f/user-security-u2f.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.doubleAuth.u2f", [
+angular.module("UserAccount").controller("UserAccount.controllers.doubleAuth.u2f", [
     "$scope",
     "$q",
     "$translate",

--- a/client/app/account/user/security/u2f/user-security-u2f.service.js
+++ b/client/app/account/user/security/u2f/user-security-u2f.service.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.services").service("UserAccount.services.doubleAuth.u2f", [
+angular.module("UserAccount").service("UserAccount.services.doubleAuth.u2f", [
     "$q",
     "$window",
     "OvhHttp",

--- a/client/app/account/user/security/user-security.controller.js
+++ b/client/app/account/user/security/user-security.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.doubleAuth", [
+angular.module("UserAccount").controller("UserAccount.controllers.doubleAuth", [
     "$scope",
     "$q",
     "$translate",

--- a/client/app/account/user/security/users/add/user-users-add.controller.js
+++ b/client/app/account/user/security/users/add/user-users-add.controller.js
@@ -1,5 +1,5 @@
 "use strict";
-angular.module("UserAccount.controllers").controller("UserAccountUsersAddCtrl", class UserAccountUsersAddCtrl {
+angular.module("UserAccount").controller("UserAccountUsersAddCtrl", class UserAccountUsersAddCtrl {
 
     constructor ($scope, User, UseraccountUsersService, Alerter, $translate) {
         this.$scope = $scope;

--- a/client/app/account/user/security/users/delete/user-users-delete.controller.js
+++ b/client/app/account/user/security/users/delete/user-users-delete.controller.js
@@ -1,5 +1,5 @@
 "use strict";
-angular.module("UserAccount.controllers").controller("UserAccountUsersDeleteCtrl", class UserAccountUsersDeleteCtrl {
+angular.module("UserAccount").controller("UserAccountUsersDeleteCtrl", class UserAccountUsersDeleteCtrl {
 
     constructor ($scope, UseraccountUsersService, Alerter, $translate) {
         this.$scope = $scope;

--- a/client/app/account/user/security/users/disable/user-users-disable.controller.js
+++ b/client/app/account/user/security/users/disable/user-users-disable.controller.js
@@ -1,5 +1,5 @@
 "use strict";
-angular.module("UserAccount.controllers").controller("UserAccountUsersDisableCtrl", class UserAccountUsersDisableCtrl {
+angular.module("UserAccount").controller("UserAccountUsersDisableCtrl", class UserAccountUsersDisableCtrl {
 
     constructor ($scope, UseraccountUsersService, Alerter, $translate) {
         this.$scope = $scope;

--- a/client/app/account/user/security/users/enable/user-users-enable.controller.js
+++ b/client/app/account/user/security/users/enable/user-users-enable.controller.js
@@ -1,5 +1,5 @@
 "use strict";
-angular.module("UserAccount.controllers").controller("UserAccountUsersEnableCtrl", class UserAccountUsersEnableCtrl {
+angular.module("UserAccount").controller("UserAccountUsersEnableCtrl", class UserAccountUsersEnableCtrl {
 
     constructor ($scope, UseraccountUsersService, Alerter, $translate) {
         this.$scope = $scope;

--- a/client/app/account/user/security/users/group.service.js
+++ b/client/app/account/user/security/users/group.service.js
@@ -1,5 +1,5 @@
 "use strict";
-angular.module("UserAccount.services").service("UseraccountGroupsService", class UseraccountGroupsService {
+angular.module("UserAccount").service("UseraccountGroupsService", class UseraccountGroupsService {
 
     constructor (OvhHttp) {
         this.ovhHttp = OvhHttp;

--- a/client/app/account/user/security/users/update/user-users-update.controller.js
+++ b/client/app/account/user/security/users/update/user-users-update.controller.js
@@ -1,5 +1,5 @@
 "use strict";
-angular.module("UserAccount.controllers").controller("UserAccountUsersUpdateCtrl", class UserAccountUsersUpdateCtrl {
+angular.module("UserAccount").controller("UserAccountUsersUpdateCtrl", class UserAccountUsersUpdateCtrl {
 
     constructor ($scope, User, UseraccountUsersService, Alerter, $translate) {
         this.$scope = $scope;

--- a/client/app/account/user/security/users/users.controller.js
+++ b/client/app/account/user/security/users/users.controller.js
@@ -1,5 +1,5 @@
 "use strict";
-angular.module("UserAccount.controllers").controller("UserAccountUsersCtrl", class UserAccountUsersCtrl {
+angular.module("UserAccount").controller("UserAccountUsersCtrl", class UserAccountUsersCtrl {
 
     constructor ($scope, User, UseraccountUsersService, UseraccountGroupsService, $q, Alerter, $translate) {
         this.$scope = $scope;

--- a/client/app/account/user/security/users/users.service.js
+++ b/client/app/account/user/security/users/users.service.js
@@ -1,5 +1,5 @@
 "use strict";
-angular.module("UserAccount.services").service("UseraccountUsersService", class UseraccountUsersService {
+angular.module("UserAccount").service("UseraccountUsersService", class UseraccountUsersService {
 
     constructor (OvhHttp) {
         this.ovhHttp = OvhHttp;

--- a/client/app/account/user/services.module.js
+++ b/client/app/account/user/services.module.js
@@ -1,1 +1,0 @@
-angular.module("UserAccount.services", []);

--- a/client/app/account/user/ssh/add/cloud/user-ssh-add-cloud.controller.js
+++ b/client/app/account/user/ssh/add/cloud/user-ssh-add-cloud.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.ssh.cloud.add", [
+angular.module("UserAccount").controller("UserAccount.controllers.ssh.cloud.add", [
     "$scope",
     "UserAccount.services.ssh",
     "$window",

--- a/client/app/account/user/ssh/add/dedicated/user-ssh-add-dedicated.controller.js
+++ b/client/app/account/user/ssh/add/dedicated/user-ssh-add-dedicated.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.ssh.dedicated.add", [
+angular.module("UserAccount").controller("UserAccount.controllers.ssh.dedicated.add", [
     "$scope",
     "$translate",
     "UserAccount.services.ssh",

--- a/client/app/account/user/ssh/delete/user-ssh-delete.controller.js
+++ b/client/app/account/user/ssh/delete/user-ssh-delete.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.ssh.delete", [
+angular.module("UserAccount").controller("UserAccount.controllers.ssh.delete", [
     "$scope",
     "$translate",
     "UserAccount.services.ssh",

--- a/client/app/account/user/ssh/user-ssh.controller.js
+++ b/client/app/account/user/ssh/user-ssh.controller.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.ssh", [
+angular.module("UserAccount").controller("UserAccount.controllers.ssh", [
     "$scope",
     "$q",
     "$translate",

--- a/client/app/account/user/ssh/user-ssh.service.js
+++ b/client/app/account/user/ssh/user-ssh.service.js
@@ -1,4 +1,4 @@
-angular.module("UserAccount.services").service("UserAccount.services.ssh", [
+angular.module("UserAccount").service("UserAccount.services.ssh", [
     "OvhHttp",
     "$q",
     "constants",

--- a/client/app/account/user/ssh/view/user-ssh-view.controller.js
+++ b/client/app/account/user/ssh/view/user-ssh-view.controller.js
@@ -1,3 +1,3 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.ssh.view", ($scope) => {
+angular.module("UserAccount").controller("UserAccount.controllers.ssh.view", ($scope) => {
     $scope.data = $scope.currentActionData;
 });

--- a/client/app/account/user/user.controller.js
+++ b/client/app/account/user/user.controller.js
@@ -1,14 +1,13 @@
-angular.module("UserAccount.controllers").controller("UserAccount.controllers.main", [
+angular.module("UserAccount").controller("UserAccount.controllers.main", [
     "$scope",
     "$window",
     "$location",
     "$timeout",
     "$state",
-    "UserAccount.conf.BASE_URL",
-    function ($scope, $window, $location, $timeout, $state, USERACCOUNT_BASE_URL) {
+    function ($scope, $window, $location, $timeout, $state) {
         "use strict";
 
-        $scope.USERACCOUNT_BASE_URL = USERACCOUNT_BASE_URL;
+        $scope.USERACCOUNT_BASE_URL = "account/user/";
 
         $scope.originUrl = $location.search().redirectTo || $location.search().redirectto;
 
@@ -32,7 +31,7 @@ angular.module("UserAccount.controllers").controller("UserAccount.controllers.ma
             $scope.currentAction = action;
             $scope.currentActionData = data;
             if (action) {
-                $scope.stepPath = `${USERACCOUNT_BASE_URL}${$scope.currentAction}.html`;
+                $scope.stepPath = `${$scope.USERACCOUNT_BASE_URL}${$scope.currentAction}.html`;
                 $("#currentAction").modal({
                     keyboard: true,
                     backdrop: "static"

--- a/client/app/account/user/user.module.js
+++ b/client/app/account/user/user.module.js
@@ -2,9 +2,8 @@ angular
     .module("UserAccount")
     .config([
         "$stateProvider",
-        "UserAccount.conf.BASE_URL",
         "UserAccount.constants",
-        function ($stateProvider, USER_ACCOUNT_BASE_URL, userAccountConstants) {
+        function ($stateProvider, userAccountConstants) {
             "use strict";
 
             const target = userAccountConstants.target;


### PR DESCRIPTION
## Flattened account user to single module

### Description of the Change

Before:
- `"UserAccount.services"`
- `"UserAccount.controllers"`
- `"UserAccount.directives"`
- `"UserAccount.filters"`

After:
- `"UserAccount"`

### Next steps in summary:
- ✂️ Split routes into their own folders.
- 🔗  Add modal states. 
- ✍️ Rewrite controllers as ES6 classes.
- 💄 Improve UI.
- ⚙️ Prefer `OvhApi` over `OvhHttp`.

Everything will be tackled into another PRs for more readability.

Feel free to give me your feedback 🎉.

cc @jleveugle @Jisay @frenautvh 