### PR TITLE
fix: won't display autorenew banner and input when not needed

### DIFF
--- a/client/app/account/billing/autoRenew/billing-autoRenew.controller.js
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.controller.js
@@ -128,19 +128,24 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
             },
             error: null,
             getNicRenewParam () {
-                $scope.nicRenew.loading = true;
-                return AutoRenew.getAutorenew()
-                    .then(({ active, renewDay }) => {
-                        $scope.nicRenew.initialized = true;
-                        $scope.nicRenew.active = active;
-                        $scope.nicRenew.renewDay = renewDay;
-                    })
-                    .catch((error) => {
-                        $scope.nicRenew.error = error.statusText;
-                    })
-                    .finally(() => {
-                        $scope.nicRenew.loading = false;
-                    });
+                if (_($scope.services).get("data.userMustApproveAutoRenew", false)) {
+                    $scope.nicRenew.loading = true;
+
+                    return AutoRenew.getAutorenew()
+                        .then(({ active, renewDay }) => {
+                            $scope.nicRenew.initialized = true;
+                            $scope.nicRenew.active = active;
+                            $scope.nicRenew.renewDay = renewDay;
+                        })
+                        .catch((error) => {
+                            $scope.nicRenew.error = error.statusText;
+                        })
+                        .finally(() => {
+                            $scope.nicRenew.loading = false;
+                        });
+                }
+
+                return $q.when();
             },
             setNicRenewParam () {
                 $scope.nicRenew.updateLoading = true;

--- a/client/app/account/billing/autoRenew/billing-autoRenew.html
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.html
@@ -10,7 +10,7 @@
 
         <div class="alert alert-danger"
              role="alert"
-             data-ng-if="!automaticRenewV2Mean.loading && automaticRenewV2Mean.available && (!automaticRenewV2Mean.allowed || (automaticRenewV2Mean.allowed && !nicRenew.active))">
+             data-ng-if="!automaticRenewV2Mean.loading && automaticRenewV2Mean.available && (!automaticRenewV2Mean.allowed || (automaticRenewV2Mean.allowed && !nicRenew.active)) && services.data.userMustApproveAutoRenew">
             <button type="button"
                     class="close"
                     data-ng-click="automaticRenewV2Mean.noMeanMessageClose()"
@@ -77,7 +77,7 @@
         </form>
 
         <form class="row"
-              data-ng-if="automaticRenewV2Mean.available && automaticRenewV2Mean.allowed">
+              data-ng-if="automaticRenewV2Mean.available && automaticRenewV2Mean.allowed && services.data.userMustApproveAutoRenew">
             <div class="form-group col-md-4">
                 <label for="autorenewDaySelect"
                        class="control-label"


### PR DESCRIPTION
## Won't display autorenew banner and input when not needed

### Warnings

Requires Stash PR **billing-autorenew-services#12** to be merged before testing && prodding

### Description of the Change

The "My Services" considered all autorenew services to be the same but they are not

### Benefits

* Users with no "automaticV2012" services won't be asked to activate autorenew when it's not needed
* Users with no "automaticV2012" won't be able to select the day when autorenew will be done as it's not possible 

