### PR TITLE
fix: won't display autorenew banner and input when not needed

### DIFF
--- a/client/app/account/billing/autoRenew/billing-autoRenew.controller.js
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.controller.js
@@ -683,7 +683,7 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
             });
 
             $q.all([$scope.getServices($scope.count, $scope.offset), userPromise, paymentMeansPromise, renewAlignUrlPromise, userGuidePromise, serviceTypePromise, userCertificatesPromise])
-                .finally(() => $scope.nicRenew.getNicRenewParam())
+                .then(() => $scope.nicRenew.getNicRenewParam())
                 .finally(() => ($scope.initLoading = false));
         }
 

--- a/client/app/account/billing/autoRenew/billing-autoRenew.controller.js
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.controller.js
@@ -41,8 +41,6 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
             text: $translate.instant("autorenew_service_type_ALL")
         };
 
-        let initLoading = true;
-
         $scope.loaded = false;
         $scope.user = null;
         $scope.expandHostingDomain = {};
@@ -261,13 +259,6 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
         $scope.getServices = function (count, offset) {
             $scope.count = count;
             $scope.offset = offset;
-
-            // TODO - clear up this mess
-            if (initLoading) {
-                return $q.when();
-            }
-
-            // end of mess
 
             $scope.services.loading = true;
             $scope.services.selected = [];
@@ -622,7 +613,7 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
          */
 
         function init () {
-            initLoading = true;
+            $scope.initLoading = true;
 
             const { selectedType, searchText, renewFilter, renewalFilter, order } = $location.search();
 
@@ -636,8 +627,6 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
 
             $scope.canDisableAllDomains = false;
 
-            initLoading = false;
-
             $scope.$watch(
                 "searchText",
                 _.debounce((old, current) => {
@@ -648,6 +637,7 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
                     }
                 }, 1000)
             );
+
             $scope.$broadcast("paginationServerSide.loadPage", "1", "serviceTable");
 
             const userPromise = User.getUser().then((user) => {
@@ -691,7 +681,7 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
 
             $q.all([$scope.getServices($scope.count, $scope.offset), userPromise, paymentMeansPromise, renewAlignUrlPromise, userGuidePromise, serviceTypePromise, userCertificatesPromise])
                 .finally(() => $scope.nicRenew.getNicRenewParam())
-                .finally(() => (initLoading = false));
+                .finally(() => ($scope.initLoading = false));
         }
 
         init();

--- a/client/app/account/billing/autoRenew/billing-autoRenew.controller.js
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.controller.js
@@ -117,7 +117,9 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
         };
         $scope.servicesDetails = [];
 
-        $scope.serviceTypeObject = ALL_SERVICE_TYPES;
+        $scope.serviceTypeObject = {
+            value: ALL_SERVICE_TYPES
+        };
 
         $scope.nicRenew = {
             renewDays: _.range(1, 30),
@@ -545,7 +547,7 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
         };
 
         $scope.onSelectedTypeChanged = function () {
-            const type = $scope.serviceTypeObject;
+            const type = $scope.serviceTypeObject.value;
             $scope.services.selectedType = type ? type.key : null;
 
             $scope.clearSelectedServices();
@@ -667,12 +669,12 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
                 $scope.servicesTypes.unshift(ALL_SERVICE_TYPES);
 
                 // sets the model of the type select input.
-                $scope.serviceTypeObject = _.find($scope.servicesTypes, {
+                $scope.serviceTypeObject.value = _.find($scope.servicesTypes, {
                     key: $scope.services.selectedType
                 });
 
-                if (!$scope.serviceTypeObject) {
-                    $scope.serviceTypeObject = ALL_SERVICE_TYPES;
+                if (!$scope.serviceTypeObject.value) {
+                    $scope.serviceTypeObject.value = ALL_SERVICE_TYPES;
                 }
             });
 

--- a/client/app/account/billing/autoRenew/billing-autoRenew.controller.js
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.controller.js
@@ -264,7 +264,7 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
 
             // TODO - clear up this mess
             if (initLoading) {
-                return;
+                return $q.when();
             }
 
             // end of mess
@@ -277,7 +277,7 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
             const selectedRenewal = $scope.renewalFilter.model === 0 || $scope.renewalFilter.model === "0" ? null : $scope.renewalFilter.model;
             const selectedOrder = $scope.orderByState;
 
-            AutoRenew.getServices(count, offset, $scope.searchText, selectedType, selectedRenew, selectedRenewal, JSON.stringify(selectedOrder), $scope.nicBillingFilter.model)
+            return AutoRenew.getServices(count, offset, $scope.searchText, selectedType, selectedRenew, selectedRenewal, JSON.stringify(selectedOrder), $scope.nicBillingFilter.model)
                 .then((result) => {
                     $scope.nbServices = result.count;
 
@@ -636,7 +636,6 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
 
             $scope.canDisableAllDomains = false;
 
-            const autorenewSettingsPromise = $scope.nicRenew.getNicRenewParam();
             initLoading = false;
 
             $scope.$watch(
@@ -690,7 +689,9 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
                 $scope.canDisableAllDomains = _.includes(results, "domains-batch-autorenew");
             });
 
-            $q.all([autorenewSettingsPromise, userPromise, paymentMeansPromise, renewAlignUrlPromise, userGuidePromise, serviceTypePromise, userCertificatesPromise]).finally(() => (initLoading = false));
+            $q.all([$scope.getServices($scope.count, $scope.offset), userPromise, paymentMeansPromise, renewAlignUrlPromise, userGuidePromise, serviceTypePromise, userCertificatesPromise])
+                .finally(() => $scope.nicRenew.getNicRenewParam())
+                .finally(() => (initLoading = false));
         }
 
         init();

--- a/client/app/account/billing/autoRenew/billing-autoRenew.controller.js
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.controller.js
@@ -128,19 +128,24 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
             },
             error: null,
             getNicRenewParam () {
-                $scope.nicRenew.loading = true;
-                return AutoRenew.getAutorenew()
-                    .then(({ active, renewDay }) => {
-                        $scope.nicRenew.initialized = true;
-                        $scope.nicRenew.active = active;
-                        $scope.nicRenew.renewDay = renewDay;
-                    })
-                    .catch((error) => {
-                        $scope.nicRenew.error = error.statusText;
-                    })
-                    .finally(() => {
-                        $scope.nicRenew.loading = false;
-                    });
+                if (_($scope.services).get("data.userMustApproveAutoRenew", false)) {
+                    $scope.nicRenew.loading = true;
+
+                    return AutoRenew.getAutorenew()
+                        .then(({ active, renewDay }) => {
+                            $scope.nicRenew.initialized = true;
+                            $scope.nicRenew.active = active;
+                            $scope.nicRenew.renewDay = renewDay;
+                        })
+                        .catch((error) => {
+                            $scope.nicRenew.error = error.statusText;
+                        })
+                        .finally(() => {
+                            $scope.nicRenew.loading = false;
+                        });
+                }
+
+                return $q.when();
             },
             setNicRenewParam () {
                 $scope.nicRenew.updateLoading = true;

--- a/client/app/account/billing/autoRenew/billing-autoRenew.html
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.html
@@ -10,7 +10,7 @@
 
         <div class="alert alert-danger"
              role="alert"
-             data-ng-if="!automaticRenewV2Mean.loading && automaticRenewV2Mean.available && (!automaticRenewV2Mean.allowed || (automaticRenewV2Mean.allowed && !nicRenew.active))">
+             data-ng-if="!automaticRenewV2Mean.loading && automaticRenewV2Mean.available && (!automaticRenewV2Mean.allowed || (automaticRenewV2Mean.allowed && !nicRenew.active)) && services.data.userMustApproveAutoRenew">
             <button type="button"
                     class="close"
                     data-ng-click="automaticRenewV2Mean.noMeanMessageClose()"
@@ -77,7 +77,7 @@
         </form>
 
         <form class="row"
-              data-ng-if="automaticRenewV2Mean.available && automaticRenewV2Mean.allowed">
+              data-ng-if="automaticRenewV2Mean.available && automaticRenewV2Mean.allowed && services.data.userMustApproveAutoRenew">
             <div class="form-group col-md-4">
                 <label for="autorenewDaySelect"
                        class="control-label"

--- a/client/app/account/billing/autoRenew/billing-autoRenew.html
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.html
@@ -34,31 +34,6 @@
             </ul>
         </div>
 
-        <div class="alert alert-info"
-             role="alert"
-             data-ng-if="automaticRenewV2Mean.available && !hideAutorenewMassMigrationAlert">
-            <button type="button"
-                    class="close"
-                    data-ng-click="hideAutorenewMassMigrationAlert = true"
-                    data-dismiss="alert">
-            </button>
-            <span data-translate="autorenew_service_renew_mass_migration_soon"></span>
-        </div>
-
-        <p class="alert alert-info"
-           data-ng-if="guide"
-           role="alert">
-            <span data-translate="autorenew_service_autorenew_guide_help"></span>
-            <a data-ng-href="{{guide}}"
-               target="_blank"
-               rel="noopener">
-                <span data-translate="autorenew_guide_help"></span>
-                <i class="fa fa-external-link"
-                   aria-hidden="true">
-                </i>
-            </a>
-        </p>
-
         <form class="row"
               data-ng-if="nicBillingFilter.values.length > 1">
             <div class="form-group col-md-4">

--- a/client/app/account/billing/autoRenew/billing-autoRenew.html
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.html
@@ -21,17 +21,15 @@
                     title="{{ 'browser_alert_close' | translate }}"
                     data-dismiss="alert">
             </button>
-            <ul>
-                <li data-ng-if="!automaticRenewV2Mean.allowed" data-translate="autorenew_service_renew_requires_mean_and_date"></li>
-                <li data-ng-if="automaticRenewV2Mean.allowed && !nicRenew.active">
+                <p data-ng-if="!automaticRenewV2Mean.allowed" data-translate="autorenew_service_renew_requires_mean_and_date"></p>
+                <p data-ng-if="automaticRenewV2Mean.allowed && !nicRenew.active">
                     <span data-translate="autorenew_service_activate_alert"></span>
                     <button class="btn btn-default"
                             type="button"
                             data-ng-click="setAction('active', { nicRenew: nicRenew }, 'autoRenew')"
                             data-translate="autorenew_service_active_title">
                     </button>
-                </li>
-            </ul>
+                </p>
         </div>
 
         <form class="row"

--- a/client/app/account/billing/autoRenew/billing-autoRenew.html
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.html
@@ -186,7 +186,7 @@
                         <select class="form-control input-sm"
                                 data-ng-options="type.text for type in servicesTypes"
                                 data-ng-disabled="!servicesTypes"
-                                data-ng-model="serviceTypeObject"
+                                data-ng-model="serviceTypeObject.value"
                                 data-ng-click="loaded = true"
                                 data-ng-change="onSelectedTypeChanged()">
                         </select>

--- a/client/app/account/billing/autoRenew/billing-autoRenew.html
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.html
@@ -21,15 +21,15 @@
                     title="{{ 'browser_alert_close' | translate }}"
                     data-dismiss="alert">
             </button>
-                <p data-ng-if="!automaticRenewV2Mean.allowed" data-translate="autorenew_service_renew_requires_mean_and_date"></p>
-                <p data-ng-if="automaticRenewV2Mean.allowed && !nicRenew.active">
-                    <span data-translate="autorenew_service_activate_alert"></span>
-                    <button class="btn btn-default"
-                            type="button"
-                            data-ng-click="setAction('active', { nicRenew: nicRenew }, 'autoRenew')"
-                            data-translate="autorenew_service_active_title">
-                    </button>
-                </p>
+            <p data-ng-if="!automaticRenewV2Mean.allowed" data-translate="autorenew_service_renew_requires_mean_and_date"></p>
+            <p data-ng-if="automaticRenewV2Mean.allowed && !nicRenew.active">
+                <span data-translate="autorenew_service_activate_alert"></span>
+                <button class="btn btn-default"
+                        type="button"
+                        data-ng-click="setAction('active', { nicRenew: nicRenew }, 'autoRenew')"
+                        data-translate="autorenew_service_active_title">
+                </button>
+            </p>
         </div>
 
         <form class="row"
@@ -42,9 +42,9 @@
                 <select id="billingAutoRenewNicBillingSelect"
                         class="form-control"
                         name="billingAutoRenew"
-                        data-ng-model-options='{debounce: 500}'
+                        data-ng-model-options='{ debounce: 500 }'
                         data-ng-model="nicBillingFilter.model"
-                        data-ng-change="onNicBillingChange();"
+                        data-ng-change="onNicBillingChange()"
                         data-ng-options="nicBilling for nicBilling in nicBillingFilter.values track by nicBilling"                        >
                     <option value=""
                             data-translate="autorenew_service_autorenew_contact_filter_all">
@@ -98,8 +98,7 @@
                         class="btn btn-default"
                         data-export-csv="getDatasToExport()"
                         data-export-csv-separator=";"
-                        data-ng-disabled="load.exportCSV"
-                        >
+                        data-ng-disabled="load.exportCSV">
                         <span data-translate="billing_export_csv"></span>
                 </button>
                 <div class="btn-group">
@@ -143,10 +142,10 @@
                            maxlength="50"
                            placeholder="{{ 'autorenew_service_name' | translate }}"
                            data-ng-model-options="{ debounce: 1000 }"
-                           data-ng-model="searchText"
+                           data-ng-model="searchText.value"
                            data-ng-change="onSearchTextChanged()"
                            data-ng-attr-title="{{ 'autorenew_search_input_title' | translate }}"
-                           autofocus />
+                           autofocus>
                     <span class="input-group-addon">
                         <i class="fa fa-search"></i>
                     </span>
@@ -154,155 +153,155 @@
             </div>
         </div>
 
-            <table class="table table-hover">
-                <thead>
-                    <tr>
-                        <th scope="col"
-                            class="align-middle">
-                            <span class="sr-only"
-                                  data-translate="autorenew_service_select_all_checkbox"></span>
-                            <input type="checkbox"
-                                   data-tri-state-checkbox="delegationSelectAll"
-                                   data-tsc-ids-all="services.data.list.results"
-                                   data-tsc-ids-selected="services.selected"
-                                   data-tsc-on-click="checkboxStateChange(state)"
-                                   data-ng-attr-title="{{ 'autorenew_service_select_all_checkbox' | translate }}" />
-                            <span class="d-inline-block"
-                                  data-ng-if="!services.loading"
-                                  data-linkedpopover="{{BILLING_BASE_URL + 'autoRenew/popoverMenu.html'}}"
-                                  data-linkedpopover-placement="right"
-                                  data-linkedpopover-single="true"
-                                  data-linkedpopover-remote="true" >
-                                <button type="button"
-                                        class="btn btn-xs btn-link"
-                                        data-ng-attr-title="{{ 'exchange_tab_ACCOUNTS_menu_account_tooltip' | translate }}" >
-                                    <span class="fa fa-filter"
-                                          aria-hidden="true">
-                                    </span>
-                                </button>
-                            </span>
-                        </th>
-                        <th scope="col"
-                            class="align-middle">
-                            <select class="form-control input-sm"
-                                    data-ng-options="type.text for type in servicesTypes"
-                                    data-ng-disabled="!servicesTypes"
-                                    data-ng-model="serviceTypeObject"
-                                    data-ng-click="loaded = true"
-                                    data-ng-change="onSelectedTypeChanged()">
-                            </select>
-                        </th>
-                        <th scope="col"
-                            class="align-middle">
-                            <a href=""
-                               data-ng-click="order('serviceId');"
-                               data-translate="autorenew_service_name"></a>
-                            <i data-ng-if="orderByState.predicate == 'serviceId' && !fuseServicesOpen()"
-                               data-ng-class="{
-                                   'fa fa-chevron-up': !orderByState.reverse,
-                                   'fa fa-chevron-down': orderByState.reverse
-                               }">
+        <table class="table table-hover">
+            <thead>
+                <tr>
+                    <th scope="col"
+                        class="align-middle">
+                        <span class="sr-only"
+                                data-translate="autorenew_service_select_all_checkbox"></span>
+                        <input type="checkbox"
+                                data-tri-state-checkbox="delegationSelectAll"
+                                data-tsc-ids-all="services.data.list.results"
+                                data-tsc-ids-selected="services.selected"
+                                data-tsc-on-click="checkboxStateChange(state)"
+                                data-ng-attr-title="{{ 'autorenew_service_select_all_checkbox' | translate }}" />
+                        <span class="d-inline-block"
+                                data-ng-if="!services.loading"
+                                data-linkedpopover="{{BILLING_BASE_URL + 'autoRenew/popoverMenu.html'}}"
+                                data-linkedpopover-placement="right"
+                                data-linkedpopover-single="true"
+                                data-linkedpopover-remote="true" >
+                            <button type="button"
+                                    class="btn btn-xs btn-link"
+                                    data-ng-attr-title="{{ 'exchange_tab_ACCOUNTS_menu_account_tooltip' | translate }}" >
+                                <span class="fa fa-filter"
+                                        aria-hidden="true">
+                                </span>
+                            </button>
+                        </span>
+                    </th>
+                    <th scope="col"
+                        class="align-middle">
+                        <select class="form-control input-sm"
+                                data-ng-options="type.text for type in servicesTypes"
+                                data-ng-disabled="!servicesTypes"
+                                data-ng-model="serviceTypeObject"
+                                data-ng-click="loaded = true"
+                                data-ng-change="onSelectedTypeChanged()">
+                        </select>
+                    </th>
+                    <th scope="col"
+                        class="align-middle">
+                        <a href=""
+                            data-ng-click="order('serviceId');"
+                            data-translate="autorenew_service_name"></a>
+                        <i data-ng-if="orderByState.predicate == 'serviceId' && !fuseServicesOpen()"
+                            data-ng-class="{
+                                'fa fa-chevron-up': !orderByState.reverse,
+                                'fa fa-chevron-down': orderByState.reverse
+                            }">
+                        </i>
+                    </th>
+                    <th scope="col"
+                        class="align-middle">
+                        <a href=""
+                            data-ng-click="order('expiration');">
+                            <span data-translate="autorenew_service_date"></span>
+                            <i data-ng-if="orderByState.predicate == 'expiration'"
+                                data-ng-class="{
+                                    'fa fa-chevron-up' : !orderByState.reverse,
+                                    'fa fa-chevron-down' : orderByState.reverse
+                                }">
                             </i>
-                        </th>
-                        <th scope="col"
-                            class="align-middle">
-                            <a href=""
-                               data-ng-click="order('expiration');">
-                                <span data-translate="autorenew_service_date"></span>
-                                <i data-ng-if="orderByState.predicate == 'expiration'"
-                                   data-ng-class="{
-                                       'fa fa-chevron-up' : !orderByState.reverse,
-                                       'fa fa-chevron-down' : orderByState.reverse
-                                   }">
-                                </i>
-                            </a>
-                            <select class="form-control input-sm"
-                                    data-ng-if="!services.loading"
-                                    data-ng-options="(('services_filter_duration_' + renew) | translate) for renew in renewFilter.values"
-                                    data-ng-model="renewFilter.model"
-                                    data-ng-change="onSelectedrenewChange()">
-                            </select>
-                        </th>
-                        <th scope="col"
-                            class="align-middle">
-                            <a href=""
-                               data-ng-click="order('renewLabel');">
-                                <span data-translate="autorenew_service_renew_frequency_title"></span>
-                                <i data-ng-if="orderByState.predicate == 'renewLabel'"
-                                   data-ng-class="{
-                                        'fa fa-chevron-up' : !orderByState.reverse,
-                                        'fa fa-chevron-down' : orderByState.reverse
-                                   }">
-                                </i>
-                            </a>
-                            <select class="form-control input-sm"
-                                    data-ng-if="!services.loading"
-                                    data-ng-options="key as value for (key, value) in renewalFilter.labels"
-                                    data-ng-model="renewalFilter.model"
-                                    data-ng-change="onSelectedRenewalChange()">
-                            </select>
-                        </th>
-                        <th scope="col"
-                            class="align-middle"
-                            data-translate="autorenew_service_action_title">
-                        </th>
-                    </tr>
-                </thead>
+                        </a>
+                        <select class="form-control input-sm"
+                                data-ng-if="!services.loading"
+                                data-ng-options="(('services_filter_duration_' + renew) | translate) for renew in renewFilter.values"
+                                data-ng-model="renewFilter.model"
+                                data-ng-change="onSelectedrenewChange()">
+                        </select>
+                    </th>
+                    <th scope="col"
+                        class="align-middle">
+                        <a href=""
+                            data-ng-click="order('renewLabel');">
+                            <span data-translate="autorenew_service_renew_frequency_title"></span>
+                            <i data-ng-if="orderByState.predicate == 'renewLabel'"
+                                data-ng-class="{
+                                    'fa fa-chevron-up' : !orderByState.reverse,
+                                    'fa fa-chevron-down' : orderByState.reverse
+                                }">
+                            </i>
+                        </a>
+                        <select class="form-control input-sm"
+                                data-ng-if="!services.loading"
+                                data-ng-options="key as value for (key, value) in renewalFilter.labels"
+                                data-ng-model="renewalFilter.model"
+                                data-ng-change="onSelectedRenewalChange()">
+                        </select>
+                    </th>
+                    <th scope="col"
+                        class="align-middle"
+                        data-translate="autorenew_service_action_title">
+                    </th>
+                </tr>
+            </thead>
 
-                <tbody data-ng-show="services.loading">
-                    <tr>
-                        <td colspan="6"
-                            class="text-center">
-                            <oui-spinner data-size="s"></oui-spinner>
-                        </td>
-                    </tr>
-                </tbody>
+            <tbody data-ng-show="services.loading">
+                <tr>
+                    <td colspan="6"
+                        class="text-center">
+                        <oui-spinner data-size="s"></oui-spinner>
+                    </td>
+                </tr>
+            </tbody>
 
-                <tbody data-ng-show="services.data && services.data.list.results.length == 0 && !services.loading">
-                    <tr>
-                        <td class="text-center"
-                            colspan="6">
-                            <span data-translate="autorenew_empty"></span>
-                        </td>
-                    </tr>
-                </tbody>
+            <tbody data-ng-show="services.data && services.data.list.results.length == 0 && !services.loading">
+                <tr>
+                    <td class="text-center"
+                        colspan="6">
+                        <span data-translate="autorenew_empty"></span>
+                    </td>
+                </tr>
+            </tbody>
 
-                <tbody data-ng-show="services.error">
-                    <tr>
-                        <td colspan="6">
-                            <div class="alert" data-ng-class="alertType">
-                                <span data-ng-bind-html="services.error"></span>
-                                <button type="button"
-                                        class="close"
-                                        data-ng-click="message=null"
-                                        data-dismiss="alert">
-                                </button>
-                            </div>
-                        </td>
-                    </tr>
-                </tbody>
+            <tbody data-ng-show="services.error">
+                <tr>
+                    <td colspan="6">
+                        <div class="alert" data-ng-class="alertType">
+                            <span data-ng-bind-html="services.error"></span>
+                            <button type="button"
+                                    class="close"
+                                    data-ng-click="message=null"
+                                    data-dismiss="alert">
+                            </button>
+                        </div>
+                    </td>
+                </tr>
+            </tbody>
 
-                <tbody data-ng-show="services.data && !services.loading">
-                    <!-- COMMON SERVICES -->
-                    <tr data-ng-repeat-start="service in services.data.list.results"
-                        data-ng-class="{'pointer': !editionDisabled(service)}"
-                        data-ng-include="BILLING_BASE_URL + 'autoRenew/common/billing-autoRenew-common.html'">
-                    </tr>
+            <tbody data-ng-show="services.data && !services.loading">
+                <!-- COMMON SERVICES -->
+                <tr data-ng-repeat-start="service in services.data.list.results"
+                    data-ng-class="{'pointer': !editionDisabled(service)}"
+                    data-ng-include="BILLING_BASE_URL + 'autoRenew/common/billing-autoRenew-common.html'">
+                </tr>
 
-                    <!-- DOMAIN SERVICES -->
-                    <tr data-ng-if="service.serviceType === 'HOSTING_DOMAIN' && expandHostingDomain[service.domain]"
-                        data-ng-include="BILLING_BASE_URL + 'autoRenew/domain/billing-autoRenew-domain.html'">
+                <!-- DOMAIN SERVICES -->
+                <tr data-ng-if="service.serviceType === 'HOSTING_DOMAIN' && expandHostingDomain[service.domain]"
+                    data-ng-include="BILLING_BASE_URL + 'autoRenew/domain/billing-autoRenew-domain.html'">
 
-                    </tr>
+                </tr>
 
-                    <!-- HOSTING SERVICES -->
-                    <tr data-ng-if="service.serviceType === 'HOSTING_DOMAIN' && expandHostingDomain[service.domain]"
-                        data-ng-include="BILLING_BASE_URL + 'autoRenew/hosting/billing-autoRenew-hosting.html'"
-                        data-ng-repeat-end>
-                    </tr>
-                </tbody>
+                <!-- HOSTING SERVICES -->
+                <tr data-ng-if="service.serviceType === 'HOSTING_DOMAIN' && expandHostingDomain[service.domain]"
+                    data-ng-include="BILLING_BASE_URL + 'autoRenew/hosting/billing-autoRenew-hosting.html'"
+                    data-ng-repeat-end>
+                </tr>
+            </tbody>
 
-            </table>
+        </table>
         <div data-pagination-server-side="serviceTable"
              data-pagination-server-side-function="getServices"
              data-pagination-server-side-paginated-stuff="services.data"

--- a/client/app/account/billing/autoRenew/billing-autoRenew.html
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.html
@@ -4,7 +4,11 @@
         <h1 data-translate="autorenew_title"></h1>
     </div>
 
-    <div class="tab-content">
+    <div class="text-center" data-ng-if="initLoading">
+        <oui-spinner data-size="l"></oui-spinner>
+    </div>
+
+    <div class="tab-content" data-ng-if="!initLoading">
 
         <div data-ovh-alert></div>
 


### PR DESCRIPTION
## Won't display autorenew banner and input when not needed

### Description of the Change

The "My Services" considered all autorenew services to be the same but they are not

### Benefits

* Users with no "automaticV2012" services won't be asked to activate autorenew when it's not needed
* Users with no "automaticV2012" won't be able to select the day when autorenew will be done as it's not possible 

