### PR TITLE
fix(billing.autorenew): display autorenew activation button again

### DIFF
--- a/client/app/account/billing/autoRenew/billing-autoRenew.constants.js
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.constants.js
@@ -1,0 +1,3 @@
+angular
+    .module("Billing.constants")
+    .constant("SUBSIDIARIES_WITH_RECENT_AUTORENEW", ["FR", "CA", "QC", "WE", "WS", "ASIA", "SG", "AU"]);

--- a/client/app/account/billing/autoRenew/billing-autoRenew.controller.js
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.controller.js
@@ -22,8 +22,9 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
     "BillingrenewHelper",
     "User",
     "$translate",
+    "SUBSIDIARIES_WITH_RECENT_AUTORENEW",
 
-    function ($scope, $location, $filter, $q, $http, $window, $timeout, Alerter, AUTORENEW_EVENT, constants, billingUrls, BILLING_BASE_URL, AutoRenew, PaymentInformation, renewHelper, User, $translate) {
+    function ($scope, $location, $filter, $q, $http, $window, $timeout, Alerter, AUTORENEW_EVENT, constants, billingUrls, BILLING_BASE_URL, AutoRenew, PaymentInformation, renewHelper, User, $translate, SUBSIDIARIES_WITH_RECENT_AUTORENEW) {
         "use strict";
 
         /**
@@ -277,9 +278,10 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
                 .then((result) => {
                     $scope.nbServices = result.count;
 
-                    const userMustApproveAutoRenew = _($scope.services).get("data.userMustApproveAutoRenew", null);
                     $scope.services.data = result;
+                    $scope.services.data.userSubsidiaryHasRecentAutorenew = _(SUBSIDIARIES_WITH_RECENT_AUTORENEW).includes($scope.user.ovhSubsidiary);
 
+                    const userMustApproveAutoRenew = _($scope.services).get("data.userMustApproveAutoRenew", null);
                     if (_(userMustApproveAutoRenew).isBoolean()) {
                         $scope.services.data.userMustApproveAutoRenew = userMustApproveAutoRenew;
                     }

--- a/client/app/account/billing/autoRenew/billing-autoRenew.html
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.html
@@ -14,7 +14,7 @@
 
         <div class="alert alert-danger"
              role="alert"
-             data-ng-if="!automaticRenewV2Mean.loading && automaticRenewV2Mean.available && (!automaticRenewV2Mean.allowed || (automaticRenewV2Mean.allowed && !nicRenew.active)) && services.data.userMustApproveAutoRenew">
+             data-ng-if="!automaticRenewV2Mean.loading && automaticRenewV2Mean.available && (!automaticRenewV2Mean.allowed || (automaticRenewV2Mean.allowed && !nicRenew.active)) && !services.data.userSubsidiaryHasRecentAutorenew">
             <button type="button"
                     class="close"
                     data-ng-click="automaticRenewV2Mean.noMeanMessageClose()"


### PR DESCRIPTION
## Display autorenew activation button again

Internal reference: SCFRCA-1622

### Description of the Change

Before : the autorenew activation button was hidden for all countries
Now: the autorenew activation button is displayed to some countries