### PR TITLE
chore(deps): bump ovh-angular-otrs to v6.1.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4943,8 +4943,8 @@ ovh-angular-http@^3.0.1:
     lodash "~3.3.0"
 
 ovh-angular-otrs@^6.0.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/ovh-angular-otrs/-/ovh-angular-otrs-6.1.1.tgz#b8ed8acf35c00ccf662da5769873dfb7407784f6"
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/ovh-angular-otrs/-/ovh-angular-otrs-6.1.2.tgz#59af35d64418599852fb0b08d045ccd416cea2b8"
 
 ovh-angular-pagination-front@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
## Bump `ovh-angular-otrs` to `v6.1.2`

### Description of the Change

1c3fe16 — chore(deps): bump ovh-angular-otrs to v6.1.2

/cc @jleveugle @Jisay @frenautvh @cbourgois 
