### PR TITLE
fix(*): text on edit dedicated service popup overflows out of modal

### DIFF
--- a/client/app/account/billing/autoRenew/update/billing-autoRenew-update.html
+++ b/client/app/account/billing/autoRenew/update/billing-autoRenew-update.html
@@ -9,61 +9,57 @@
              data-wizard-step-valid="hasChanged">
             <p data-ng-bind-html="'autorenew_service_update_intro' | translate"></p>
 
-            <table class="table table-hover">
-                <thead>
-                    <tr>
-                        <th scope="col"
-                            data-translate="autorenew_service_name">
-                        </th>
-                        <th scope="col"
-                            data-translate="autorenew_service_type">
-                        </th>
-                        <th scope="col"
-                            class="text-nowrap">
-                            <span data-translate="autorenew_service_renew"></span>
-                        </th>
-                        <th scope="col"
-                            class="text-nowrap">
-                            <span data-translate="autorenew_service_frequency"></span>
-                        </th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr data-ng-repeat="service in selectedServices | orderBy:'serviceType':false track by $index">
-                        <th scope="row">
-                            <span data-ng-bind="::service.serviceId | sliceContent:25"></span>
-                        </th>
-                        <td>
-                            <span data-ng-bind-html="'autorenew_service_type_'+ service.serviceType | translate"></span>
-                        </td>
-                        <td>
-                            <select name="renewType"
-                                    class="form-control"
-                                    data-ng-disabled="service.renew.automatic && service.renew.forced"
-                                    data-ng-change="onChange()"
-                                    data-ng-model="service.newRenewType">
-                                <option value="auto" data-ng-selected="service.renew.automatic"
-                                        data-translate="autorenew_service_renew_auto">
-                                </option>
-                                <option value="manuel" data-ng-selected="!service.renew.automatic"
-                                        data-translate="autorenew_service_renew_manuel">
-                                </option>
-                            </select>
-                        </td>
-                        <td class="text-center">
-                            <select name="renewPeriod"
-                                    class="form-control"
-                                    data-ng-if="service.newRenewType === 'auto' && service.possibleRenewPeriod.length > 1"
-                                    data-ng-change="onChange()"
-                                    data-ng-options="period as getPeriodTranslation(period) for period in service.possibleRenewPeriod"
-                                    data-ng-model="service.newRenewPeriod">
-                            </select>
-                            <span data-ng-if="service.newRenewType === 'auto' && service.possibleRenewPeriod.length === 1"> {{getPeriodTranslation(service.newRenewPeriod)}}</span>
-                            <span data-ng-if="service.newRenewType === 'manuel'"> - </span>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+            <div class="oui-datagrid-responsive-container">
+                <div class="oui-datagrid-responsive-container__sticky-container">
+                    <div class="oui-datagrid-responsive-container__overflow-container">
+                    <table class="oui-datagrid">
+                        <thead class="oui-datagrid__headers">
+                        <tr>
+                            <th class="oui-datagrid__header" tabindex="0" data-translate="autorenew_service_name"></th>
+                            <th class="oui-datagrid__header" tabindex="0" data-translate="autorenew_service_type"></th>
+                            <th class="oui-datagrid__header text-nowrap" tabindex="0" ><span data-translate="autorenew_service_renew"></span></th>
+                            <th class="oui-datagrid__header text-nowrap" tabindex="0"><span data-translate="autorenew_service_frequency"></span></th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                            <tr class="oui-datagrid__row" data-ng-repeat="service in selectedServices | orderBy:'serviceType':false track by $index">
+                                <td class="oui-datagrid__cell">
+                                    <span data-ng-bind="::service.serviceId | sliceContent:25"></span>
+                                </td>
+                                <td class="oui-datagrid__cell">
+                                    <span data-ng-bind-html="'autorenew_service_type_'+ service.serviceType | translate"></span>
+                                </td>
+                                <td class="oui-datagrid__cell">
+                                    <select name="renewType"
+                                            class="form-control"
+                                            data-ng-disabled="service.renew.automatic && service.renew.forced"
+                                            data-ng-change="onChange()"
+                                            data-ng-model="service.newRenewType">
+                                        <option value="auto" data-ng-selected="service.renew.automatic"
+                                                data-translate="autorenew_service_renew_auto">
+                                        </option>
+                                        <option value="manuel" data-ng-selected="!service.renew.automatic"
+                                                data-translate="autorenew_service_renew_manuel">
+                                        </option>
+                                    </select>
+                                </td>
+                                <td class="oui-datagrid__cell text-center">
+                                    <select name="renewPeriod"
+                                            class="form-control"
+                                            data-ng-if="service.newRenewType === 'auto' && service.possibleRenewPeriod.length > 1"
+                                            data-ng-change="onChange()"
+                                            data-ng-options="period as getPeriodTranslation(period) for period in service.possibleRenewPeriod"
+                                            data-ng-model="service.newRenewPeriod">
+                                    </select>
+                                    <span data-ng-if="service.newRenewType === 'auto' && service.possibleRenewPeriod.length === 1"> {{getPeriodTranslation(service.newRenewPeriod)}}</span>
+                                    <span data-ng-if="service.newRenewType === 'manuel'"> - </span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <div data-wizard-step
@@ -71,61 +67,58 @@
              data-wizard-step-valid="agree.value">
 
             <p data-ng-bind-html="'autorenew_service_update_step2_summary' | translate"></p>
-            <table class="table table-hover">
-                <thead>
-                    <tr>
-                        <th scope="col"
-                            data-translate="autorenew_service_name">
-                        </th>
-                        <th scope="col"
-                            data-translate="autorenew_service_type">
-                        </th>
-                        <th scope="col"
-                            class="text-nowrap">
-                            <span data-translate="autorenew_service_update_now"></span>
-                        </th>
-                        <th scope="col"
-                            class="text-nowrap">
-                            <span data-translate="autorenew_service_update_future"></span>
-                        </th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr data-ng-repeat="service in selectedServices | orderBy:'serviceType':false track by $index">
-                        <th scope="row">
-                            <span data-ng-bind="service.serviceId | sliceContent:25"></span>
-                        </th>
-                        <td>
-                            <span data-ng-bind="'autorenew_service_type_' + service.serviceType | translate"></span>
-                        </td>
 
-                        <td>
-                            <div data-ng-if="service.renew.automatic">
-                                <span data-translate="autorenew_service_renew_auto"></span>:
-                                <span data-ng-if="service.renew.period"
-                                      data-ng-bind="getPeriodTranslation(service.renew.period)">
-                                </span>
-                            </div>
-                            <span data-ng-if="!service.renew.automatic"
-                                  data-translate="autorenew_service_renew_manuel">
-                            </span>
-                        </td>
-
-                        <td class="text-center"
-                            data-ng-class="{'font-weight-bold': hasChange(service)}">
-                            <div data-ng-if="service.newRenewType === 'auto'">
-                                <span data-translate="autorenew_service_renew_auto"></span>:
-                                <span data-ng-if="service.newRenewPeriod"
-                                      data-ng-bind="getPeriodTranslation(service.newRenewPeriod)">
-                                </span>
-                            </div>
-                            <span data-ng-if="service.newRenewType === 'manuel'"
-                                  data-translate="autorenew_service_renew_manuel">
-                            </span>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+            <div class="oui-datagrid-responsive-container">
+                <div class="oui-datagrid-responsive-container__sticky-container">
+                    <div class="oui-datagrid-responsive-container__overflow-container">
+                    <table class="oui-datagrid">
+                        <thead class="oui-datagrid__headers">
+                        <tr>
+                            <th class="oui-datagrid__header" tabindex="0" data-translate="autorenew_service_name"></th>
+                            <th class="oui-datagrid__header" tabindex="0" data-translate="autorenew_service_type"></th>
+                            <th class="oui-datagrid__header text-nowrap" tabindex="0" ><span data-translate="autorenew_service_update_now"></span></th>
+                            <th class="oui-datagrid__header text-nowrap" tabindex="0"><span data-translate="autorenew_service_update_future"></span></th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                            <tr class="oui-datagrid__row" data-ng-repeat="service in selectedServices | orderBy:'serviceType':false track by $index">
+                                <td class="oui-datagrid__cell">
+                                    <span data-ng-bind="service.serviceId | sliceContent:25"></span>
+                                </td>
+                                <td class="oui-datagrid__cell">
+                                    <span data-ng-bind="'autorenew_service_type_' + service.serviceType | translate"></span>
+                                </td>
+        
+                                <td class="oui-datagrid__cell">
+                                    <div data-ng-if="service.renew.automatic">
+                                        <span data-translate="autorenew_service_renew_auto"></span>:
+                                        <span data-ng-if="service.renew.period"
+                                                data-ng-bind="getPeriodTranslation(service.renew.period)">
+                                        </span>
+                                    </div>
+                                    <span data-ng-if="!service.renew.automatic"
+                                            data-translate="autorenew_service_renew_manuel">
+                                    </span>
+                                </td>
+        
+                                <td class="oui-datagrid__cell text-center"
+                                    data-ng-class="{'font-weight-bold': hasChange(service)}">
+                                    <div data-ng-if="service.newRenewType === 'auto'">
+                                        <span data-translate="autorenew_service_renew_auto"></span>:
+                                        <span data-ng-if="service.newRenewPeriod"
+                                                data-ng-bind="getPeriodTranslation(service.newRenewPeriod)">
+                                        </span>
+                                    </div>
+                                    <span data-ng-if="service.newRenewType === 'manuel'"
+                                            data-translate="autorenew_service_renew_manuel">
+                                    </span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    </div>
+                </div>
+            </div>
 
             <div data-ng-if="loading.contracts"
                  class="text-center">

--- a/client/app/account/billing/autoRenew/update/billing-autoRenew-update.html
+++ b/client/app/account/billing/autoRenew/update/billing-autoRenew-update.html
@@ -4,57 +4,55 @@
          data-wizard-on-cancel="closeAction"
          data-wizard-on-finish="updateRenew"
          data-wizard-title="::'autorenew_service_update_title' | translate">
-
         <div data-wizard-step
              data-wizard-step-valid="hasChanged">
             <p data-ng-bind-html="'autorenew_service_update_intro' | translate"></p>
-
             <div class="oui-datagrid-responsive-container">
                 <div class="oui-datagrid-responsive-container__sticky-container">
                     <div class="oui-datagrid-responsive-container__overflow-container">
-                    <table class="oui-datagrid">
-                        <thead class="oui-datagrid__headers">
-                        <tr>
-                            <th class="oui-datagrid__header" tabindex="0" data-translate="autorenew_service_name"></th>
-                            <th class="oui-datagrid__header" tabindex="0" data-translate="autorenew_service_type"></th>
-                            <th class="oui-datagrid__header text-nowrap" tabindex="0" data-translate="autorenew_service_renew"></th>
-                            <th class="oui-datagrid__header text-nowrap" tabindex="0" data-translate="autorenew_service_frequency"></th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                            <tr class="oui-datagrid__row" data-ng-repeat="service in selectedServices | orderBy:'serviceType':false track by $index">
-                                <td class="oui-datagrid__cell" data-ng-bind="::service.serviceId | sliceContent:25"></td>
-                                <td class="oui-datagrid__cell">
-                                    <span data-ng-bind-html="'autorenew_service_type_'+ service.serviceType | translate"></span>
-                                </td>
-                                <td class="oui-datagrid__cell">
-                                    <select name="renewType"
-                                            class="form-control"
-                                            data-ng-disabled="service.renew.automatic && service.renew.forced"
-                                            data-ng-change="onChange()"
-                                            data-ng-model="service.newRenewType">
-                                        <option value="auto" data-ng-selected="service.renew.automatic"
+                        <table class="oui-datagrid">
+                            <thead class="oui-datagrid__headers">
+                                <tr>
+                                    <th class="oui-datagrid__header" tabindex="0" data-translate="autorenew_service_name"></th>
+                                    <th class="oui-datagrid__header" tabindex="0" data-translate="autorenew_service_type"></th>
+                                    <th class="oui-datagrid__header text-nowrap" tabindex="0" data-translate="autorenew_service_renew"></th>
+                                    <th class="oui-datagrid__header text-nowrap" tabindex="0" data-translate="autorenew_service_frequency"></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr class="oui-datagrid__row" data-ng-repeat="service in selectedServices | orderBy:'serviceType':false track by $index">
+                                    <td class="oui-datagrid__cell" data-ng-bind="::service.serviceId | sliceContent:25"></td>
+                                    <td class="oui-datagrid__cell">
+                                        <span data-ng-bind-html="'autorenew_service_type_'+ service.serviceType | translate"></span>
+                                    </td>
+                                    <td class="oui-datagrid__cell">
+                                        <select name="renewType"
+                                                class="form-control"
+                                                data-ng-disabled="service.renew.automatic && service.renew.forced"
+                                                data-ng-change="onChange()"
+                                                data-ng-model="service.newRenewType">
+                                            <option value="auto" data-ng-selected="service.renew.automatic"
                                                 data-translate="autorenew_service_renew_auto">
-                                        </option>
-                                        <option value="manuel" data-ng-selected="!service.renew.automatic"
+                                            </option>
+                                            <option value="manuel" data-ng-selected="!service.renew.automatic"
                                                 data-translate="autorenew_service_renew_manuel">
-                                        </option>
-                                    </select>
-                                </td>
-                                <td class="oui-datagrid__cell">
-                                    <select name="renewPeriod"
-                                            class="form-control"
-                                            data-ng-if="service.newRenewType === 'auto' && service.possibleRenewPeriod.length > 1"
-                                            data-ng-change="onChange()"
-                                            data-ng-options="period as getPeriodTranslation(period) for period in service.possibleRenewPeriod"
-                                            data-ng-model="service.newRenewPeriod">
-                                    </select>
-                                    <span data-ng-if="service.newRenewType === 'auto' && service.possibleRenewPeriod.length === 1" data-ng-bind="getPeriodTranslation(service.newRenewPeriod)"></span>
-                                    <span data-ng-if="service.newRenewType === 'manuel'"> - </span>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+                                            </option>
+                                        </select>
+                                    </td>
+                                    <td class="oui-datagrid__cell">
+                                        <select name="renewPeriod"
+                                                class="form-control"
+                                                data-ng-if="service.newRenewType === 'auto' && service.possibleRenewPeriod.length > 1"
+                                                data-ng-change="onChange()"
+                                                data-ng-options="period as getPeriodTranslation(period) for period in service.possibleRenewPeriod"
+                                                data-ng-model="service.newRenewPeriod">
+                                        </select>
+                                        <span data-ng-if="service.newRenewType === 'auto' && service.possibleRenewPeriod.length === 1" data-ng-bind="getPeriodTranslation(service.newRenewPeriod)"></span>
+                                        <span data-ng-if="service.newRenewType === 'manuel'"> - </span>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </div>
                 </div>
             </div>
@@ -63,68 +61,61 @@
         <div data-wizard-step
              data-wizard-step-on-load="loadContracts"
              data-wizard-step-valid="agree.value">
-
             <p data-ng-bind-html="'autorenew_service_update_step2_summary' | translate"></p>
-
             <div class="oui-datagrid-responsive-container">
                 <div class="oui-datagrid-responsive-container__sticky-container">
                     <div class="oui-datagrid-responsive-container__overflow-container">
-                    <table class="oui-datagrid">
-                        <thead class="oui-datagrid__headers">
-                        <tr>
-                            <th class="oui-datagrid__header" tabindex="0" data-translate="autorenew_service_name"></th>
-                            <th class="oui-datagrid__header" tabindex="0" data-translate="autorenew_service_type"></th>
-                            <th class="oui-datagrid__header text-nowrap" tabindex="0" data-translate="autorenew_service_update_now"></th>
-                            <th class="oui-datagrid__header text-nowrap" tabindex="0" data-translate="autorenew_service_update_future"></th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                            <tr class="oui-datagrid__row" data-ng-repeat="service in selectedServices | orderBy:'serviceType':false track by $index">
-                                <td class="oui-datagrid__cell" data-ng-bind="service.serviceId | sliceContent:25"></td>
-                                <td class="oui-datagrid__cell" data-ng-bind="'autorenew_service_type_' + service.serviceType | translate"></td>
-                                <td class="oui-datagrid__cell">
-                                    <div data-ng-if="service.renew.automatic">
-                                        <span data-translate="autorenew_service_renew_auto"></span>:
-                                        <span data-ng-if="service.renew.period"
+                        <table class="oui-datagrid">
+                            <thead class="oui-datagrid__headers">
+                                <tr>
+                                    <th class="oui-datagrid__header" tabindex="0" data-translate="autorenew_service_name"></th>
+                                    <th class="oui-datagrid__header" tabindex="0" data-translate="autorenew_service_type"></th>
+                                    <th class="oui-datagrid__header text-nowrap" tabindex="0" data-translate="autorenew_service_update_now"></th>
+                                    <th class="oui-datagrid__header text-nowrap" tabindex="0" data-translate="autorenew_service_update_future"></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr class="oui-datagrid__row" data-ng-repeat="service in selectedServices | orderBy:'serviceType':false track by $index">
+                                    <td class="oui-datagrid__cell" data-ng-bind="service.serviceId | sliceContent:25"></td>
+                                    <td class="oui-datagrid__cell" data-ng-bind="'autorenew_service_type_' + service.serviceType | translate"></td>
+                                    <td class="oui-datagrid__cell">
+                                        <div data-ng-if="service.renew.automatic">
+                                            <span data-translate="autorenew_service_renew_auto"></span>:
+                                            <span data-ng-if="service.renew.period"
                                                 data-ng-bind="getPeriodTranslation(service.renew.period)">
-                                        </span>
-                                    </div>
-                                    <span data-ng-if="!service.renew.automatic"
+                                            </span>
+                                        </div>
+                                        <span data-ng-if="!service.renew.automatic"
                                             data-translate="autorenew_service_renew_manuel">
-                                    </span>
-                                </td>
-                                <td class="oui-datagrid__cell"
-                                    data-ng-class="{'font-weight-bold': hasChange(service)}">
-                                    <div data-ng-if="service.newRenewType === 'auto'">
-                                        <span data-translate="autorenew_service_renew_auto"></span>:
-                                        <span data-ng-if="service.newRenewPeriod"
+                                        </span>
+                                    </td>
+                                    <td class="oui-datagrid__cell"
+                                        data-ng-class="{'font-weight-bold': hasChange(service)}">
+                                        <div data-ng-if="service.newRenewType === 'auto'">
+                                            <span data-translate="autorenew_service_renew_auto"></span>:
+                                            <span data-ng-if="service.newRenewPeriod"
                                                 data-ng-bind="getPeriodTranslation(service.newRenewPeriod)">
-                                        </span>
-                                    </div>
-                                    <span data-ng-if="service.newRenewType === 'manuel'"
+                                            </span>
+                                        </div>
+                                        <span data-ng-if="service.newRenewType === 'manuel'"
                                             data-translate="autorenew_service_renew_manuel">
-                                    </span>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+                                        </span>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </div>
                 </div>
             </div>
-
             <div data-ng-if="loading.contracts"
                  class="text-center">
                  <oui-spinner></oui-spinner>
             </div>
-
             <div data-ng-if="!loading.contracts && contracts.length > 0"
                  data-contracts="contracts"
                  data-full-text="false"
                  data-ng-model="agree.value">
             </div>
-
         </div>
-
     </div>
-
 </div>

--- a/client/app/account/billing/autoRenew/update/billing-autoRenew-update.html
+++ b/client/app/account/billing/autoRenew/update/billing-autoRenew-update.html
@@ -17,15 +17,13 @@
                         <tr>
                             <th class="oui-datagrid__header" tabindex="0" data-translate="autorenew_service_name"></th>
                             <th class="oui-datagrid__header" tabindex="0" data-translate="autorenew_service_type"></th>
-                            <th class="oui-datagrid__header text-nowrap" tabindex="0" ><span data-translate="autorenew_service_renew"></span></th>
-                            <th class="oui-datagrid__header text-nowrap" tabindex="0"><span data-translate="autorenew_service_frequency"></span></th>
+                            <th class="oui-datagrid__header text-nowrap" tabindex="0" data-translate="autorenew_service_renew"></th>
+                            <th class="oui-datagrid__header text-nowrap" tabindex="0" data-translate="autorenew_service_frequency"></th>
                         </tr>
                         </thead>
                         <tbody>
                             <tr class="oui-datagrid__row" data-ng-repeat="service in selectedServices | orderBy:'serviceType':false track by $index">
-                                <td class="oui-datagrid__cell">
-                                    <span data-ng-bind="::service.serviceId | sliceContent:25"></span>
-                                </td>
+                                <td class="oui-datagrid__cell" data-ng-bind="::service.serviceId | sliceContent:25"></td>
                                 <td class="oui-datagrid__cell">
                                     <span data-ng-bind-html="'autorenew_service_type_'+ service.serviceType | translate"></span>
                                 </td>
@@ -43,7 +41,7 @@
                                         </option>
                                     </select>
                                 </td>
-                                <td class="oui-datagrid__cell text-center">
+                                <td class="oui-datagrid__cell">
                                     <select name="renewPeriod"
                                             class="form-control"
                                             data-ng-if="service.newRenewType === 'auto' && service.possibleRenewPeriod.length > 1"
@@ -51,7 +49,7 @@
                                             data-ng-options="period as getPeriodTranslation(period) for period in service.possibleRenewPeriod"
                                             data-ng-model="service.newRenewPeriod">
                                     </select>
-                                    <span data-ng-if="service.newRenewType === 'auto' && service.possibleRenewPeriod.length === 1"> {{getPeriodTranslation(service.newRenewPeriod)}}</span>
+                                    <span data-ng-if="service.newRenewType === 'auto' && service.possibleRenewPeriod.length === 1" data-ng-bind="getPeriodTranslation(service.newRenewPeriod)"></span>
                                     <span data-ng-if="service.newRenewType === 'manuel'"> - </span>
                                 </td>
                             </tr>
@@ -76,19 +74,14 @@
                         <tr>
                             <th class="oui-datagrid__header" tabindex="0" data-translate="autorenew_service_name"></th>
                             <th class="oui-datagrid__header" tabindex="0" data-translate="autorenew_service_type"></th>
-                            <th class="oui-datagrid__header text-nowrap" tabindex="0" ><span data-translate="autorenew_service_update_now"></span></th>
-                            <th class="oui-datagrid__header text-nowrap" tabindex="0"><span data-translate="autorenew_service_update_future"></span></th>
+                            <th class="oui-datagrid__header text-nowrap" tabindex="0" data-translate="autorenew_service_update_now"></th>
+                            <th class="oui-datagrid__header text-nowrap" tabindex="0" data-translate="autorenew_service_update_future"></th>
                         </tr>
                         </thead>
                         <tbody>
                             <tr class="oui-datagrid__row" data-ng-repeat="service in selectedServices | orderBy:'serviceType':false track by $index">
-                                <td class="oui-datagrid__cell">
-                                    <span data-ng-bind="service.serviceId | sliceContent:25"></span>
-                                </td>
-                                <td class="oui-datagrid__cell">
-                                    <span data-ng-bind="'autorenew_service_type_' + service.serviceType | translate"></span>
-                                </td>
-        
+                                <td class="oui-datagrid__cell" data-ng-bind="service.serviceId | sliceContent:25"></td>
+                                <td class="oui-datagrid__cell" data-ng-bind="'autorenew_service_type_' + service.serviceType | translate"></td>
                                 <td class="oui-datagrid__cell">
                                     <div data-ng-if="service.renew.automatic">
                                         <span data-translate="autorenew_service_renew_auto"></span>:
@@ -100,8 +93,7 @@
                                             data-translate="autorenew_service_renew_manuel">
                                     </span>
                                 </td>
-        
-                                <td class="oui-datagrid__cell text-center"
+                                <td class="oui-datagrid__cell"
                                     data-ng-class="{'font-weight-bold': hasChange(service)}">
                                     <div data-ng-if="service.newRenewType === 'auto'">
                                         <span data-translate="autorenew_service_renew_auto"></span>:


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Title of the Pull Requests <!-- required -->
text shown on update my service popup overflows and goes out of the modal boundary

### Description of the Change
replaced HTML table with HTML version of oui-datagrid

### Benefits
provides responsive content

### Possible Drawbacks
none

### Applicable Issues
MFRWW-691