### PR TITLE
feat(billing.mean.add): sepa fields separated for France only

### DIFF
--- a/client/app/account/billing/mean/add/billing-mean-add.controller.js
+++ b/client/app/account/billing/mean/add/billing-mean-add.controller.js
@@ -3,7 +3,8 @@
  * @name Billing.controllers.Method.Add'
  * @description
  */
-angular.module("Billing.controllers").controller("Billing.controllers.Mean.Add", ($scope, $location, $q, $translate, IBAN_BIC_RULES, BillingMean, BillingUser, Alerter) => {
+angular.module("Billing.controllers").controller("Billing.controllers.Mean.Add", ($scope, $location, $q, $translate, IBAN_BIC_RULES, BillingMean, BillingUser, Alerter, User) => {
+
     $scope.loader = {
         add: false,
         means: false
@@ -119,6 +120,14 @@ angular.module("Billing.controllers").controller("Billing.controllers.Mean.Add",
 
         const meanData = BillingMean.canPaymentTypeSetDefaultAtCreation($scope.mean.type) ? $scope.mean : _.omit($scope.mean, "setDefault");
 
+        if ($scope.isFrenchCustomer) {
+            meanData.ownerAddress = `${meanData.addressNumber || ""} ${meanData.addressStreetName} ${meanData.addressPostalCode} ${meanData.addressTown}`.trim();
+            delete meanData.addressNumber;
+            delete meanData.addressStreetName;
+            delete meanData.addressPostalCode;
+            delete meanData.addressTown;
+        }
+
         return BillingMean.post(meanData)
             .then((response) => {
                 $scope.mean = {};
@@ -205,11 +214,16 @@ angular.module("Billing.controllers").controller("Billing.controllers.Mean.Add",
         $scope.meanAdded = false;
         $scope.titleTypeOfSelect = "choose"; /* used to build a translation key */
 
+
         $scope.loader.means = true;
         BillingUser.getAvailableMeans()
             .then((availableMeans) => (BillingMean.isApiSchemaLoaded() ? $q.when() : BillingMean.getApiSchemaPromise()).then(() => availableMeans.filter((meanType) => !!BillingMean.canBeAddedByUser(meanType))))
             .then((meanTypes) => {
                 setPaymentMeansInScope(meanTypes);
+            })
+            .then(() => User.getUser())
+            .then((user) => {
+                $scope.isFrenchCustomer = user.ovhSubsidiary === "FR";
             })
             .catch((error) => {
                 Alerter.set("alert-danger", $translate.instant("add_mean_unable_to_get_payment_means"), error);

--- a/client/app/account/billing/mean/add/billing-mean-add.html
+++ b/client/app/account/billing/mean/add/billing-mean-add.html
@@ -96,57 +96,147 @@
                         </div>
                     </div>
 
-                    <div class="form-group">
-                        <label for="ownerAddress"
-                               class="control-label required"
-                               data-translate="paymentMean_label_ownerAddress">
-                        </label>
-                        <input type="text"
-                               id="ownerAddress"
-                               name="ownerAddress"
-                               class="form-control"
-                               data-ng-model="mean.ownerAddress"
-                               data-ng-minlength="5"
-                               data-ng-maxlength="255"
-                               required/>
-                        <div data-ng-repeat="(error, hasError) in paymentMeanForm.ownerAddress.$error"
-                             role="alert">
-                            <span class="text-danger"
-                                  data-ng-bind="('paymentMean_error_' + error) | translate"
-                                  data-ng-if="hasError && paymentMeanForm.ownerAddress.$dirty" >
-                            </span>
-                        </div>
-                    </div>
+                    <fieldset>
+                        <legend class="mb-5" data-translate="paymentMean_label_ownerAddress"></legend>
+                        <div data-ng-if="isFrenchCustomer">
+                            <div class="form-group">
+                                <label for="addressNumber"
+                                        class="control-label"
+                                        data-translate="paymentMean_label_addressNumber">
+                                </label>
+                                <input type="text"
+                                        id="addressNumber"
+                                        name="addressNumber"
+                                        class="form-control"
+                                        data-ng-model="mean.addressNumber"
+                                        data-ng-maxlength="255">
+                                <div data-ng-repeat="(error, hasError) in paymentMeanForm.addressNumber.$error"
+                                    role="alert">
+                                    <span class="text-danger"
+                                        data-ng-bind="('paymentMean_error_' + error) | translate"
+                                        data-ng-if="hasError && paymentMeanForm.addressNumber.$dirty" >
+                                    </span>
+                                </div>
+                            </div>
 
-                    <div class="form-group">
-                        <label for="ownerName"
-                               class="control-label required"
-                               data-translate="paymentMean_label_ownerName">
-                        </label>
-                        <input type="text"
-                               id="ownerName"
-                               name="ownerName"
-                               class="form-control"
-                               data-ng-model="mean.ownerName"
-                               data-ng-minlength="5"
-                               data-ng-maxlength="255"
-                               required/>
-                        <div data-ng-repeat="(error, hasError) in paymentMeanForm.ownerName.$error"
-                             role="alert">
-                            <span class="text-danger"
-                                  data-ng-bind="('paymentMean_error_' + error) | translate"
-                                  data-ng-if="hasError && paymentMeanForm.ownerName.$dirty">
-                            </span>
-                        </div>
-                    </div>
+                            <div class="form-group">
+                                <label for="addressStreetName"
+                                        class="control-label required"
+                                        data-translate="paymentMean_label_addressStreetName">
+                                </label>
+                                <input type="text"
+                                        id="addressStreetName"
+                                        name="addressStreetName"
+                                        class="form-control"
+                                        data-ng-model="mean.addressStreetName"
+                                        data-ng-maxlength="255"
+                                        required>
+                                <div data-ng-repeat="(error, hasError) in paymentMeanForm.addressStreetName.$error"
+                                    role="alert">
+                                    <span class="text-danger"
+                                        data-ng-bind="('paymentMean_error_' + error) | translate"
+                                        data-ng-if="hasError && paymentMeanForm.addressStreetName.$dirty" >
+                                    </span>
+                                </div>
+                            </div>
 
+                            <div class="form-group">
+                                <label for="addressPostalCode"
+                                        class="control-label required"
+                                        data-translate="paymentMean_label_addressPostalCode">
+                                </label>
+                                <input type="number"
+                                        id="addressPostalCode"
+                                        name="addressPostalCode"
+                                        class="form-control"
+                                        data-ng-model="mean.addressPostalCode"
+                                        data-ng-pattern="/^\d{5}$/"
+                                        min="01000"
+                                        min="99999"
+                                        required>
+                                <div data-ng-repeat="(error, hasError) in paymentMeanForm.addressPostalCode.$error"
+                                    role="alert">
+                                    <span class="text-danger"
+                                        data-ng-bind="('paymentMean_error_addressPostalCode_' + error) | translate"
+                                        data-ng-if="hasError && paymentMeanForm.addressPostalCode.$dirty" >
+                                    </span>
+                                </div>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="addressTown"
+                                        class="control-label required"
+                                        data-translate="paymentMean_label_addressTown">
+                                </label>
+                                <input type="text"
+                                        id="addressTown"
+                                        name="addressTown"
+                                        class="form-control"
+                                        data-ng-model="mean.addressTown"
+                                        data-ng-maxlength="255"
+                                        required>
+                                <div data-ng-repeat="(error, hasError) in paymentMeanForm.addressTown.$error"
+                                    role="alert">
+                                    <span class="text-danger"
+                                        data-ng-bind="('paymentMean_error_' + error) | translate"
+                                        data-ng-if="hasError && paymentMeanForm.addressTown.$dirty" >
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div
+                            data-ng-if="!isFrenchCustomer"
+                            class="form-group">
+                            <label for="ownerAddress"
+                                    class="control-label required"
+                                    data-translate="paymentMean_label_ownerAddress">
+                            </label>
+                            <input type="text"
+                                    id="ownerAddress"
+                                    name="ownerAddress"
+                                    class="form-control"
+                                    data-ng-model="mean.ownerAddress"
+                                    data-ng-maxlength="255"
+                                    required>
+                            <div data-ng-repeat="(error, hasError) in paymentMeanForm.ownerAddress.$error"
+                                    role="alert">
+                                <span class="text-danger"
+                                        data-ng-bind="('paymentMean_error_' + error) | translate"
+                                        data-ng-if="hasError && paymentMeanForm.ownerAddress.$dirty" >
+                                </span>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="ownerName"
+                                class="control-label required"
+                                data-translate="paymentMean_label_ownerName">
+                            </label>
+                            <input type="text"
+                                id="ownerName"
+                                name="ownerName"
+                                class="form-control"
+                                data-ng-model="mean.ownerName"
+                                data-ng-minlength="5"
+                                data-ng-maxlength="255"
+                                required/>
+                            <div data-ng-repeat="(error, hasError) in paymentMeanForm.ownerName.$error"
+                                role="alert">
+                                <span class="text-danger"
+                                    data-ng-bind="('paymentMean_error_' + error) | translate"
+                                    data-ng-if="hasError && paymentMeanForm.ownerName.$dirty">
+                                </span>
+                            </div>
+                        </div>
+                    </fieldset>
                 </div>
 
                 <div class="checkbox"
-                     data-ng-show="canPaymentTypeSetDefaultAtCreation(mean.type)">
+                        data-ng-show="canPaymentTypeSetDefaultAtCreation(mean.type)">
                     <label>
                         <input type="checkbox"
-                               data-ng-model="mean.setDefault" />
+                                data-ng-model="mean.setDefault" />
                         <span data-translate="payment_mean_set_default_after_validation"></span>
                     </label>
                 </div>

--- a/client/app/account/billing/translations/Messages_fr_FR.xml
+++ b/client/app/account/billing/translations/Messages_fr_FR.xml
@@ -761,7 +761,11 @@
    <translation id="paymentMean_label_creditcard_expiration" qtlid="30406">Expiration</translation>
    <translation id="paymentMean_label_iban" qtlid="177015">IBAN</translation>
    <translation id="paymentMean_label_bic" qtlid="177028">BIC</translation>
-   <translation id="paymentMean_label_ownerName" qtlid="177041">Nom du propriétaire du compte</translation>
+   <translation id="paymentMean_label_addressNumber">Numéro</translation>
+   <translation id="paymentMean_label_addressStreetName">Nom de la voie</translation>
+   <translation id="paymentMean_label_addressPostalCode">Code postal</translation>
+   <translation id="paymentMean_label_addressTown">Ville</translation>
+   <translation id="paymentMean_label_ownerName">Nom et prénom du propriétaire ou nom de l'organisation propriétaire</translation>
    <translation id="paymentMean_label_ownerAddress" qtlid="177054">Adresse du propriétaire du compte</translation>
    <translation id="paymentMean_error_bic_bank" qtlid="177067">Le code de la banque est incorrect.</translation>
    <translation id="paymentMean_error_bic_valid" qtlid="177080">Le BIC est invalide.</translation>
@@ -771,6 +775,10 @@
    <translation id="paymentMean_error_iban_key" qtlid="177132">La clef de l'IBAN est invalide.</translation>
    <translation id="paymentMean_error_iban_valid" qtlid="177145">L'IBAN est invalide.</translation>
    <translation id="paymentMean_error_minlength" qtlid="179680">Il faut au moins 5 caractères.</translation>
+   <translation id="paymentMean_error_addressPostalCode_required" qtlid="177093">Ce champs est requis.</translation>
+   <translation id="paymentMean_error_addressPostalCode_min">Le code postal n'est pas valide.</translation>
+   <translation id="paymentMean_error_addressPostalCode_max">Le code postal n'est pas valide.</translation>
+   <translation id="paymentMean_error_addressPostalCode_pattern">Le code postal doit être composé de 5 chiffres.</translation>
    <translation id="paymentMean_error_maxlength" qtlid="177171">Le texte doit être plus petit que 255 caractères.</translation>
    <translation id="paymentType_delete_error" qtlid="177184">Erreur lors de la suppression du moyen de paiement</translation>
    <translation id="paymentType_modify_error" qtlid="436354">Erreur lors de la modification du moyen de paiement</translation>


### PR DESCRIPTION
## SEPA fields separated for France only

Internal reference: SCFRCA-1336

No need for translations, this is just for France

### Description of the Change

When trying to add a new means of payment, the fields are more detailed when the customer is in France