### PR TITLE
hotfix action dropdown menu does not work in mobile

### DIFF
--- a/client/app/css/less/utils/variables.less
+++ b/client/app/css/less/utils/variables.less
@@ -208,3 +208,9 @@
 // -------------------------
 
 @defaultPopoverFont      : @grey6;
+
+//
+// droupdown menu
+// -------------------------
+
+@oui-dropdown-menu-zindex: 1000;


### PR DESCRIPTION
action drop-down menu links does not work in mobile devices

Closes #MFRWW-753

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Title of the Pull Requests <!-- required -->
Action drop-down links do not work in mobile

### Description of the Change
OVH uses bootstrap in dedicated server UI to show the action drop-down menu. For some reason, default dropdown-menu style (z-index) is overridden and set to 100. This was causing the problem. I have reset this value to default value, that is, 1000.

### Benefits
Dropdown menu works properly when used in mobile, touch devices

### Possible Drawbacks
none

### Applicable Issues
MFRWW-753
