### PR TITLE
fix(deps): bump ovh-api-services to v3.12.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5013,8 +5013,8 @@ ovh-angular-user-pref@^0.3.1:
   resolved "https://registry.yarnpkg.com/ovh-angular-user-pref/-/ovh-angular-user-pref-0.3.1.tgz#07f5792513651f3262ae4879c174423649b08307"
 
 ovh-api-services@^3.5.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-3.11.0.tgz#16546000f9e84e3fb62002c4129cb4653b65194d"
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-3.12.1.tgz#49a086b0a566a0189433b9c17444eb9d76b9406f"
   dependencies:
     grunt-injector "^0.6.0"
 


### PR DESCRIPTION
## Bump `ovh-api-services` to `v3.12.1`

### Description of the Change

4f47966 — fix(deps): bump ovh-api-services to v3.12.1

/cc @jleveugle @Jisay @frenautvh @cbourgois 