### PR TITLE
chore(deps): bump ovh-angular-otrs

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4965,8 +4965,8 @@ ovh-angular-http@^3.0.1:
     lodash "~3.3.0"
 
 ovh-angular-otrs@^6.0.1:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/ovh-angular-otrs/-/ovh-angular-otrs-6.1.2.tgz#59af35d64418599852fb0b08d045ccd416cea2b8"
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/ovh-angular-otrs/-/ovh-angular-otrs-6.1.3.tgz#e1e1ee7eae9f172765cf7c80db1e510ceae59c2f"
 
 ovh-angular-pagination-front@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
## Bump ovh-angular-otrs to `v6.1.3`

### Description of the Change

eab06c6 - chore(deps): bump ovh-angular-otrs

bump:
- ovh-angular-otrs `v6.1.2` to `v6.1.3`

/cc @lizardK @jleveugle @Jisay @frenautvh @cbourgois 