### PR TITLE
feat(billing.autorenew): SMS pack menu item redirects to renewal page

### DIFF
--- a/client/app/account/billing/autoRenew/billing-autoRenew.controller.js
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.controller.js
@@ -268,6 +268,9 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew"
             }
         };
 
+        $scope.buildSMSCreditBuyingURL = (service) => `${constants.MANAGER_URLS.telecom}sms/${service.serviceId}/order`;
+        $scope.buildSMSAutomaticRenewalURL = (service) => `${constants.MANAGER_URLS.telecom}sms/${service.serviceId}/options/recredit`;
+
         /**
          * @doc method
          * @methodOf Billing.controller:AutoRenewCtrl

--- a/client/app/account/billing/autoRenew/common/billing-autoRenew-common.html
+++ b/client/app/account/billing/autoRenew/common/billing-autoRenew-common.html
@@ -39,6 +39,22 @@
     </button>
 
     <oui-action-menu
+        data-ng-if="service.serviceType === 'SMS'"
+        data-aria-label="{{:: 'autorenew_service_action_menu_tooltip' | translate }}"
+        data-compact
+        data-align="end">
+        <oui-action-menu-item
+            data-href="{{:: buildSMSCreditBuyingURL(service) }}"
+            data-external="true"
+            data-text="{{:: 'autorenew_service_action_menu_smsPack_credit' | translate }}"></oui-action-menu-item>
+
+        <oui-action-menu-item
+            data-href="{{:: buildSMSAutomaticRenewalURL(service) }}"
+            data-external="true"
+            data-text="{{:: 'autorenew_service_action_menu_smsPack_automaticRenew' | translate }}"></oui-action-menu-item>
+    </oui-action-menu>
+
+    <oui-action-menu
         data-ng-if="!service.subProducts && service.serviceType !== 'SMS'"
         data-aria-label="{{:: 'autorenew_service_action_menu_tooltip' | translate }}"
         data-compact

--- a/client/app/account/billing/common/renew-helper.service.js
+++ b/client/app/account/billing/common/renew-helper.service.js
@@ -31,9 +31,10 @@ angular
             }
 
             if (angular.isObject(service)) {
-                if (service.serviceType === "EMAIL_DOMAIN") {
+                if (_(["EMAIL_DOMAIN", "SMS"]).includes(service.serviceType)) {
                     return this.$translate.instant("autorenew_service_renew_paid");
                 }
+
                 if (!_.isEmpty(service.subProducts)) {
                     return "";
                 }

--- a/client/app/account/billing/translations/Messages_fr_FR.xml
+++ b/client/app/account/billing/translations/Messages_fr_FR.xml
@@ -55,6 +55,8 @@
    <translation id="autorenew_service_selection_checkbox" qtlid="300668">Sélectionner ce service.</translation>
    <translation id="autorenew_service_action_title" qtlid="72809">Actions</translation>
    <translation id="autorenew_service_action_menu_tooltip" qtlid="300681">Plus d'actions sur ce service</translation>
+   <translation id="autorenew_service_action_menu_smsPack_credit">Ajouter des crédits</translation>
+   <translation id="autorenew_service_action_menu_smsPack_automaticRenew">Configurer la recharge automatique</translation>
    <translation id="autorenew_service_action_title" qtlid="72809">Actions</translation>
    <translation id="autorenew_service_autorenew_active_checkbox_label" qtlid="369401">Autoriser le renouvellement automatique sur les services désignés</translation>
    <translation id="autorenew_service_autorenew_day" qtlid="229515">Jour de renouvellement automatique:</translation>


### PR DESCRIPTION
## SMS pack menu item redirects to renewal page


### Description of the Change

Before: no menu item for SMS pack 
After: two menu items to help users renew their products

ref: SCFRCA-2022