### PR TITLE
fix(dedicated server): alert background color fix

### DIFF
--- a/client/app/dedicated/server/bandwidth/cancel/dedicated-server-bandwidth-cancel.controller.js
+++ b/client/app/dedicated/server/bandwidth/cancel/dedicated-server-bandwidth-cancel.controller.js
@@ -14,6 +14,7 @@ angular.module("App").controller("ServerCancelBandwidthCtrl", ($rootScope, $scop
                 $rootScope.$broadcast("dedicated.informations.bandwidth");
             })
             .catch((data) => {
+                data.type = "ERROR";
                 $scope.setMessage($translate.instant("server_cancel_bandwidth_cancel_error"), data);
             })
             .finally(() => {

--- a/client/app/dedicated/server/bandwidth/order/dedicated-server-bandwidth-order.controller.js
+++ b/client/app/dedicated/server/bandwidth/order/dedicated-server-bandwidth-order.controller.js
@@ -152,6 +152,7 @@ angular.module("App").controller("ServerOrderBandwidthCtrl", ($scope, $statePara
             },
             (data) => {
                 $scope.resetAction();
+                data.data.type = "ERROR";
                 $scope.setMessage($translate.instant("server_order_bandwidth_error"), data.data);
             }
         );

--- a/client/app/dedicated/server/dedicated-server.controller.js
+++ b/client/app/dedicated/server/dedicated-server.controller.js
@@ -56,6 +56,7 @@ angular.module("App").controller("ServerCtrl", (NO_AUTORENEW_COUNTRIES, WEATHERM
     });
 
     $scope.setMessage = (message, data) => {
+
         let messageToSend = message;
         let i = 0;
         $scope.alertType = "";
@@ -240,6 +241,7 @@ angular.module("App").controller("ServerCtrl", (NO_AUTORENEW_COUNTRIES, WEATHERM
             .catch((data) => {
                 $scope.loadingServerInformations = false;
                 $scope.loadingServerError = true;
+                data.type = "ERROR";
                 $scope.setMessage($translate.instant("server_dashboard_loading_error"), data);
             });
     }
@@ -256,6 +258,7 @@ angular.module("App").controller("ServerCtrl", (NO_AUTORENEW_COUNTRIES, WEATHERM
                 };
             },
             (err) => {
+                err.data.type = "ERROR";
                 $scope.setMessage($translate.instant("server_dashboard_loading_error"), err.data);
             }
         );
@@ -315,6 +318,7 @@ angular.module("App").controller("ServerCtrl", (NO_AUTORENEW_COUNTRIES, WEATHERM
             (data) => {
                 $scope.disable.reboot = false;
                 $scope.$broadcast("dedicated.informations.reboot.done");
+                data.type = "ERROR";
                 $scope.setMessage($translate.instant("server_configuration_reboot_fail_task"), data);
             }
         );
@@ -379,6 +383,7 @@ angular.module("App").controller("ServerCtrl", (NO_AUTORENEW_COUNTRIES, WEATHERM
             })
             .catch((data) => {
                 $scope.disable.install = false;
+                data.type = "ERROR";
                 $scope.setMessage($translate.instant("server_configuration_installation_fail_task", { t0: $scope.server.name }), data);
             });
     }

--- a/client/app/dedicated/server/dns/add/dedicated-server-dns-add.controller.js
+++ b/client/app/dedicated/server/dns/add/dedicated-server-dns-add.controller.js
@@ -42,6 +42,7 @@ angular.module("App").controller("AddSecondaryDnsCtrl", ($scope, $translate, Ser
             (err) => {
                 $scope.loading = false;
                 $scope.resetAction();
+                err.type = "ERROR";
                 $scope.setMessage($translate.instant("server_configuration_ips_cannotfetch"), err);
             }
         );
@@ -68,11 +69,12 @@ angular.module("App").controller("AddSecondaryDnsCtrl", ($scope, $translate, Ser
             () => {
                 $scope.resetAction();
                 $scope.loading = false;
-                $scope.setMessage($translate.instant("server_configuration_secondarydns_add_success", { t0: $scope.server.name }));
+                $scope.setMessage($translate.instant("server_configuration_secondarydns_add_success", { t0: $scope.server.name }), true);
             },
             (err) => {
                 $scope.resetAction();
                 $scope.loading = false;
+                err.type = "ERROR";
                 $scope.setMessage($translate.instant("server_configuration_secondarydns_add_fail"), err);
             }
         );

--- a/client/app/dedicated/server/dns/dedicated-server-dns.controller.js
+++ b/client/app/dedicated/server/dns/dedicated-server-dns.controller.js
@@ -8,6 +8,7 @@ angular.module("App").controller("SecondaryDnsCtrl", ($scope, $timeout, $statePa
             }
         }),
         (err) => {
+            err.type = "ERROR";
             $scope.setMessage($translate.instant("server_configuration_secondary_dns_fail"), err);
         }
     );

--- a/client/app/dedicated/server/dns/delete/dedicated-server-dns-delete.controller.js
+++ b/client/app/dedicated/server/dns/delete/dedicated-server-dns-delete.controller.js
@@ -8,11 +8,12 @@ angular.module("App").controller("DeleteSecondaryDnsCtrl", ($scope, $stateParams
             () => {
                 $scope.loadingDelete = false;
                 $scope.resetAction();
-                $scope.setMessage($translate.instant("server_configuration_delete_secondary_dns_success", { t0: $scope.secdns.domain }));
+                $scope.setMessage($translate.instant("server_configuration_delete_secondary_dns_success", { t0: $scope.secdns.domain }), true);
             },
             (err) => {
                 $scope.loadingDelete = false;
                 $scope.resetAction();
+                err.type = "ERROR";
                 $scope.setMessage($translate.instant("server_configuration_delete_secondary_dns_fail", { t0: $scope.secdns.domain }), err);
             }
         );

--- a/client/app/dedicated/server/firewall/disable/dedicated-server-firewall-disable.controller.js
+++ b/client/app/dedicated/server/firewall/disable/dedicated-server-firewall-disable.controller.js
@@ -8,6 +8,7 @@ angular.module("App").controller("ServerFirewallAsaDisableCtrl", ($scope, $state
             },
             (data) => {
                 $scope.resetAction();
+                data.type = "ERROR";
                 $scope.setMessage($translate.instant("server_configuration_firewall_asa_disable_step1_loading_error"), data);
             }
         );

--- a/client/app/dedicated/server/firewall/enable/dedicated-server-firewall-enable.controller.js
+++ b/client/app/dedicated/server/firewall/enable/dedicated-server-firewall-enable.controller.js
@@ -8,6 +8,7 @@ angular.module("App").controller("ServerFirewallAsaEnableCtrl", ($scope, $stateP
             },
             (data) => {
                 $scope.resetAction();
+                data.type = "ERROR";
                 $scope.setMessage($translate.instant("server_configuration_firewall_asa_enable_step1_loading_error"), data);
             }
         );
@@ -17,9 +18,11 @@ angular.module("App").controller("ServerFirewallAsaEnableCtrl", ($scope, $stateP
         $scope.resetAction();
         ServerFirewallAsa.changeFirewallState($stateParams.productId, true).then(
             (data) => {
+                data.type = "INFO";
                 $scope.setMessage($translate.instant("server_configuration_firewall_asa_enable_success"), data);
             },
             (data) => {
+                data.type = "ERROR";
                 $scope.setMessage($translate.instant("server_configuration_firewall_asa_enable_fail"), data);
             }
         );

--- a/client/app/dedicated/server/firewall/order/dedicated-server-firewall-order.controller.js
+++ b/client/app/dedicated/server/firewall/order/dedicated-server-firewall-order.controller.js
@@ -16,6 +16,7 @@ angular.module("App").controller("ServerFirewallAsaOrderCtrl", ($scope, $statePa
                 },
                 (data) => {
                     $scope.resetAction();
+                    data.type = "ERROR";
                     $scope.setMessage($translate.instant("server_configuration_firewall_asa_order_step1_loading_error"), data);
                 }
             );
@@ -25,6 +26,7 @@ angular.module("App").controller("ServerFirewallAsaOrderCtrl", ($scope, $statePa
                 },
                 (err) => {
                     $scope.resetAction();
+                    err.type = "ERROR";
                     $scope.setMessage($translate.instant("server_configuration_firewall_asa_order_step1_loading_error"), err);
                 }
             );
@@ -44,6 +46,7 @@ angular.module("App").controller("ServerFirewallAsaOrderCtrl", ($scope, $statePa
             },
             (data) => {
                 $scope.resetAction();
+                data.type = "ERROR";
                 $scope.setMessage($translate.instant("server_configuration_firewall_asa_order_fail"), data);
             }
         );

--- a/client/app/dedicated/server/firewall/rule/dedicated-server-firewall-rule.controller.js
+++ b/client/app/dedicated/server/firewall/rule/dedicated-server-firewall-rule.controller.js
@@ -169,9 +169,11 @@ angular.module("App").controller("ServerFirewallAddRuleCtrl", [
 
             Server.addFirewallRule($scope.data.block.value.ip, $scope.data.ip.ip, $scope.rule).then(
                 (data) => {
+                    data.type = "INFO";
                     $scope.setMessage($translate.instant("server_configuration_firewall_add_rule_success", { t0: $scope.server.name }), data);
                 },
                 (data) => {
+                    data.type = "ERROR";
                     $scope.setMessage($translate.instant("server_configuration_firewall_add_rule_fail"), data.data);
                 }
             );
@@ -187,9 +189,11 @@ angular.module("App").controller("FirewallRemoveRuleCtrl", ($scope, $translate, 
 
         Server.removeFirewallRule($scope.data.block.value.ip, $scope.data.ip.ip, $scope.data.rule.sequence).then(
             (data) => {
+                data.type = "INFO";
                 $scope.setMessage($translate.instant("server_configuration_firewall_remove_rule_success"), data);
             },
             (data) => {
+                data.type = "ERROR";
                 $scope.setMessage($translate.instant("server_configuration_firewall_remove_rule_fail"), data);
             }
         );
@@ -236,15 +240,18 @@ angular.module("App").controller("ServerIpToggleFirewallCtrl", [
             if (newStatus === $scope.firewallStatuses.NOT_CONFIGURED) {
                 Server.createFirewall($scope.data.block.ip, $scope.data.ip.ip).then(
                     (data) => {
+                        data.type = "INFO";
                         $scope.setMessage($translate.instant("server_configuration_firewall_new_success", { t0: $scope.data.ip.ip }), data);
                     },
                     (data) => {
+                        data.type = "ERROR";
                         $scope.setMessage($translate.instant("server_configuration_firewall_new_failed", { t0: $scope.data.ip.ip }), data);
                     }
                 );
             } else {
                 Server.toggleFirewall($scope.data.block.ip, $scope.data.ip.ip, newStatus).then(
                     (data) => {
+                        data.type = "INFO";
                         if (newStatus === $scope.firewallStatuses.DEACTIVATED) {
                             $scope.setMessage($translate.instant("server_configuration_firewall_disable_success", { t0: $scope.data.ip.ip }), data);
                         } else if (newStatus === $scope.firewallStatuses.ACTIVATED) {
@@ -254,6 +261,7 @@ angular.module("App").controller("ServerIpToggleFirewallCtrl", [
                         }
                     },
                     (data) => {
+                        data.type = "ERROR";
                         if (newStatus === $scope.firewallStatuses.DEACTIVATED) {
                             $scope.setMessage($translate.instant("server_configuration_firewall_disable_failed", { t0: $scope.data.ip.ip }), data);
                         } else if (newStatus === $scope.firewallStatuses.ACTIVATED) {

--- a/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js
+++ b/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js
@@ -481,6 +481,7 @@ angular
                 (data) => {
                     $scope.loader.loading = false;
                     $scope.resetAction();
+                    data.type = "ERROR";
                     $scope.setMessage($translate.instant("server_configuration_installation_ovh_fail_partition_schemes", { t0: $scope.constants.server.name }), data.data);
                 }
             );

--- a/client/app/dedicated/server/ip/dedicated-server-ip-mitigation.controller.js
+++ b/client/app/dedicated/server/ip/dedicated-server-ip-mitigation.controller.js
@@ -25,6 +25,7 @@ angular.module("App").controller("ServerIpMitigationCtrl", ($scope, $translate, 
 
         Server.updateMitigation($scope.selectedIpAndBlock.block.ip, $scope.selectedIpAndBlock.ip.ip, newMitigationStatus).then(
             (data) => {
+                data.type = "INFO";
                 if (newMitigationStatus === "AUTO") {
                     $scope.setMessage($translate.instant("server_configuration_mitigation_auto_success", { t0: $scope.selectedIpAndBlock.ip.ip }), data);
                 } else {
@@ -32,6 +33,7 @@ angular.module("App").controller("ServerIpMitigationCtrl", ($scope, $translate, 
                 }
             },
             (data) => {
+                data.type = "ERROR";
                 if (newMitigationStatus === "AUTO") {
                     $scope.setMessage($translate.instant("server_configuration_mitigation_auto_failed", { t0: $scope.selectedIpAndBlock.ip.ip }), data);
                 } else {

--- a/client/app/dedicated/server/ip/dedicated-server-ip.controller.js
+++ b/client/app/dedicated/server/ip/dedicated-server-ip.controller.js
@@ -294,6 +294,7 @@ angular.module("App").controller("ServerIpAntispamCtrl", ($rootScope, $scope, $l
                     $scope.$broadcast("paginationServerSide.reload", "antispamPeriods");
                 },
                 (data) => {
+                    data.type = "ERROR";
                     $scope.setMessage($translate.instant("server_configuration_antispam_error", { t0: $scope.ipspam.ip }), data.data);
                 }
             );
@@ -360,6 +361,7 @@ angular.module("App").controller("ServerIpAntispamDetailsCtrl", ($scope, $transl
             (reason) => {
                 $scope.tableLoading = false;
                 $scope.resetAction();
+                reason.type = "INFO";
                 $scope.setMessage($translate.instant("server_configuration_mitigation_auto_success"), reason);
             }
         );

--- a/client/app/dedicated/server/statistics/dedicated-server-statistics.controller.js
+++ b/client/app/dedicated/server/statistics/dedicated-server-statistics.controller.js
@@ -103,6 +103,7 @@ angular.module("controllers").controller("controllers.Server.Stats", (
             .catch((data) => {
                 $scope.serverStatsLoad.error = true;
                 if (nameServer && data) {
+                    data.data.type = "ERROR";
                     $scope.setMessage($translate.instant("server_tab_STATS_loading_fail"), data.data);
                 }
             })
@@ -117,6 +118,7 @@ angular.module("controllers").controller("controllers.Server.Stats", (
                 $scope.setMessage($translate.instant("server_remove_hack_success"));
             },
             (data) => {
+                data.type = "ERROR";
                 $scope.setMessage($translate.instant("server_remove_hack_fail"), data.data);
             }
         );
@@ -140,6 +142,7 @@ angular.module("controllers").controller("controllers.Server.Stats", (
             .catch((data) => {
                 $scope.serverStatsLoad.error = true;
                 if (data) {
+                    data.type = "ERROR";
                     $scope.setMessage($translate.instant("server_tab_STATS_loading_fail"), data.data);
                 }
             })


### PR DESCRIPTION
MFRWW-894

### Requirements

The background color of the alerts are white for a few error messages. This has to be fixed.

## Alert background color fix


### Description of the Change

It was found that the alert type was not getting passed in a few places, resulting in white background for alerts. This has been fixed by passing in the alert type information in the required places.