### PR TITLE
fix(*): duplicate error message shown on PCC General Information tab

### DIFF
--- a/client/app/dedicatedCloud/dedicatedCloud.controller.js
+++ b/client/app/dedicatedCloud/dedicatedCloud.controller.js
@@ -18,7 +18,6 @@ angular.module("App").controller("DedicatedCloudCtrl", [
 
         $scope.HDS_READY_NOTIFICATION = "HDS_READY_NOTIFICATION";
 
-        $scope.alerts = { dashboard: "dedicatedCloud_alert" };
         $scope.loadingInformations = true;
         $scope.loadingError = false;
         $scope.dedicatedCloud = null;

--- a/client/app/dedicatedCloud/security/dedicatedCloud-security.controller.js
+++ b/client/app/dedicatedCloud/security/dedicatedCloud-security.controller.js
@@ -127,7 +127,7 @@ angular.module("App").controller("DedicatedCloudSecurityCtrl", function ($rootSc
     };
 
     self.onError = function (data) {
-        $scope.setMessage($translate.instant("dedicatedCloud_dashboard_loading_error"), data.data);
+        $scope.setMessage($translate.instant("dedicatedCloud_dashboard_loading_error"), data.data || data);
     };
 
     $scope.loadInfo();

--- a/client/app/dedicatedCloud/vmware-option/dedicatedCloud-vmware-option.controller.js
+++ b/client/app/dedicatedCloud/vmware-option/dedicatedCloud-vmware-option.controller.js
@@ -59,7 +59,8 @@ angular.module("App").controller("DedicatedCloudVMwareOptionCtrl", ($scope, $sta
                             message: err.data ? "" : err.message,
                             type: "ERROR"
                         }
-                    })
+                    }),
+                    angular.extend(err, { type: "ERROR" })
                 );
             });
     }


### PR DESCRIPTION
on PCC general information page, the same error message is shown twice, one with error and another with a warning.

Closes #MFRWW-895

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Title of the Pull Requests
Duplicate error messages are shown on PCC general Information page


### Description of the Change
Two messages, one error and another warning, are shown on UI page with the same content. I have removed the unnecessary alerts array defined which was causing a message to appear twice.

### Benefits
Fixes issue MFRWW-895

### Possible Drawbacks
none

### Applicable Issues
MFRWW-895
