### PR TITLE
fix(billing.autorenew): prevent renewal&cancellation for all

### DIFF
--- a/client/app/account/billing/autoRenew/debtBeforePaying/billing-autoRenew-debtBeforePaying.controller.js
+++ b/client/app/account/billing/autoRenew/debtBeforePaying/billing-autoRenew-debtBeforePaying.controller.js
@@ -17,7 +17,7 @@ angular.module("Billing.controllers").controller("Billing.controllers.AutoRenew.
         const delay = 800;
         this.$scope.setAction();
         this.$timeout(() => {
-            this.$state.go("app.account.billing.history");
+            this.$state.go("app.account.billing.main.history");
         }, delay);
     }
 });

--- a/client/app/account/billing/autoRenew/domain/billing-autoRenew-domain.html
+++ b/client/app/account/billing/autoRenew/domain/billing-autoRenew-domain.html
@@ -35,9 +35,17 @@
             data-text="{{:: 'autorenew_service_canceldelete_button' | translate }}"></oui-action-menu-item>
 
         <oui-action-menu-item
-            data-ng-if="service.subProducts.domain.serviceType !== 'EXCHANGE'"
+            data-ng-if="service.subProducts.domain.status !== 'PENDING_DEBT'"
+            data-disabled="service.subProducts.domain.renew.forced"
             data-href="{{:: getRenewUrl() + service.subProducts.domain.serviceId }}"
             data-external="true"
+            data-text="{{:: 'autorenew_service_renew_button' | translate }}"
+            data-aria-label="{{:: 'autorenew_service_renew_button_title' | translate: { t0: service.subProducts.domain.serviceId } }}"></oui-action-menu-item>
+
+        <oui-action-menu-item
+            data-ng-if="service.subProducts.domain.status === 'PENDING_DEBT'"
+            data-disabled="service.subProducts.domain.renew.forced"
+            data-on-click="gotoRenew(service.subProducts.domain)"
             data-text="{{:: 'autorenew_service_renew_button' | translate }}"
             data-aria-label="{{:: 'autorenew_service_renew_button_title' | translate: { t0: service.subProducts.domain.serviceId } }}"></oui-action-menu-item>
 

--- a/client/app/account/billing/autoRenew/hosting/billing-autoRenew-hosting.html
+++ b/client/app/account/billing/autoRenew/hosting/billing-autoRenew-hosting.html
@@ -32,9 +32,16 @@
             data-text="{{:: 'autorenew_service_canceldelete_button' | translate }}"></oui-action-menu-item>
 
         <oui-action-menu-item
-            data-ng-if="service.subProducts.hosting_web.serviceType !== 'EXCHANGE'"
+            data-ng-if="service.subProducts.hosting_web.status !== 'PENDING_DEBT'"
             data-href="{{:: getRenewUrl() + service.subProducts.hosting_web.serviceId }}"
             data-external="true"
+            data-text="{{:: 'autorenew_service_renew_button' | translate }}"
+            data-aria-label="{{:: 'autorenew_service_renew_button_title' | translate: { t0: service.subProducts.hosting_web.serviceId } }}"></oui-action-menu-item>
+
+        <oui-action-menu-item
+            data-ng-if="service.subProducts.hosting_web.status === 'PENDING_DEBT'"
+            data-disabled="service.subProducts.hosting_web.renew.forced"
+            data-on-click="gotoRenew(service.subProducts.hosting_web)"
             data-text="{{:: 'autorenew_service_renew_button' | translate }}"
             data-aria-label="{{:: 'autorenew_service_renew_button_title' | translate: { t0: service.subProducts.hosting_web.serviceId } }}"></oui-action-menu-item>
 


### PR DESCRIPTION
## When a user has a debt, prevent renewal & cancellation for all type of services
Internal reference: SCFRCA-2257

### Description of the Change

Concerned website/manager/Order : Dedicated
URL : https://www.ovh.com/manager/dedicated/index.html#/billing/autoRenew
Environment : Production
Browser : All of them
Do you know if we use an API ? Yes no need
What are the steps to reproduce the bug ?
Click on the menu item of a web hosting or a domain service with a debt

Click on "Pay the service" or "Terminate at expiry date"

You should not have a dialog