### PR TITLE
fix(*): terminate domain not working

### DIFF
--- a/client/app/account/billing/confirmTerminate/billing-confirmTerminate.service.js
+++ b/client/app/account/billing/confirmTerminate/billing-confirmTerminate.service.js
@@ -1,50 +1,56 @@
-angular.module('Billing.services').service('BillingTerminate', function ($q, OvhHttp) {
-  this.getServiceTypeFromPrefix = function (serviceApiPrefix) {
-    return serviceApiPrefix
-      .replace(/^\//, '')
-      .replace(/\/\{.+$/, '')
-      .replace(/\//g, '_');
-  };
-
-  this.getServiceApi = function (serviceId, forceRefresh) {
-    const params = {
-      rootPath: 'apiv6',
-      cache: 'billingTerminateService',
+angular
+  .module('Billing.services')
+  .service('BillingTerminate', function ($q, OvhHttp) {
+    this.getServiceTypeFromPrefix = function (serviceApiPrefix) {
+      return serviceApiPrefix
+        .replace(/^\//, '')
+        .replace(/\/\{.+$/, '')
+        .replace(/\//g, '_');
     };
-    if (forceRefresh) {
-      delete params.cache;
-    }
-    return OvhHttp.get(`/service/${serviceId}`, params);
-  };
 
-  this.getServiceInfo = function (serviceId) {
-    let serviceType;
-    return this.getServiceApi(serviceId)
-      .then((serviceApi) => {
-        serviceType = this.getServiceTypeFromPrefix(serviceApi.route.path);
-        return serviceApi.route.url;
-      })
-      .then(url => OvhHttp.get(`${url}/serviceInfos`, {
+    this.getServiceApi = function (serviceId, forceRefresh) {
+      const params = {
         rootPath: 'apiv6',
-      }))
-      .then(serviceInfos => Object.assign({}, serviceInfos, {
-        serviceType,
-      }));
-  };
+        cache: 'billingTerminateService',
+      };
+      if (forceRefresh) {
+        delete params.cache;
+      }
+      return OvhHttp.get(`/service/${serviceId}`, params);
+    };
 
-  this.confirmTermination = function (serviceId, serviceName, futureUse, reason,
-    commentary, token) {
-    return this.getServiceApi(serviceId)
-      .then(serviceApi => serviceApi.route.url)
-      .then(url => OvhHttp.post(`${url}/confirmTermination`, {
-        rootPath: 'apiv6',
-        data: {
-          serviceName,
-          futureUse,
-          reason,
-          commentary,
-          token,
-        },
-      }));
-  };
-});
+    this.getServiceInfo = function (serviceId) {
+      let serviceType;
+      return this.getServiceApi(serviceId)
+        .then((serviceApi) => {
+          serviceType = this.getServiceTypeFromPrefix(serviceApi.route.path);
+          return serviceApi.route.url;
+        })
+        .then(url => OvhHttp.get(`${url}/serviceInfos`, {
+          rootPath: 'apiv6',
+        }))
+        .then(serviceInfos => Object.assign({}, serviceInfos, {
+          serviceType,
+        }));
+    };
+
+    this.confirmTermination = function (
+      serviceId,
+      serviceName,
+      futureUse,
+      reason,
+      commentary,
+      token,
+    ) {
+      return this.getServiceApi(serviceId)
+        .then(serviceApi => serviceApi.route.url)
+        .then(url => OvhHttp.post(`${url}/confirmTermination`, {
+          rootPath: 'apiv6',
+          data: {
+            reason,
+            commentary,
+            token,
+          },
+        }));
+    };
+  });


### PR DESCRIPTION
confirm terminate domain throws 400 error

CLoses #MANAGER-1244

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Title of the Pull Requests 
Domain termination is not working


### Description of the Change
Problem:
Domain termination always throws 400 error.
Error:
message: "Received not described parameters: (futureUse, serviceName) while calling confirmTermination"
Request details:
{"serviceName":"publictest.ovh","futureUse":"OTHER","reason":"OTHER","token":"xxxxx"}

Solution:
Domain termination AOI has changed. It does not accept parameters passed. I have made a change to API call based on new API documentation and tested in staging. 
New API does not take serviceName and futureUse. I have removed these and tested.

### Benefits
Domain termination now works and the customer can terminate his domain account.

### Possible Drawbacks
none

### Applicable Issues
MANAGER-1244
