### PR TITLE
fix(webpack): fix broken ui-angular import

### DIFF
--- a/client/app/index.js
+++ b/client/app/index.js
@@ -14,7 +14,7 @@ import 'script-loader!components-jqueryui/ui/widgets/mouse.js';
 import 'script-loader!components-jqueryui/ui/widgets/sortable.js';
 import 'script-loader!components-jqueryui/ui/widgets/draggable.js';
 import 'angular';
-import 'ovh-ui-angular';
+import 'script-loader!ovh-ui-angular/dist/oui-angular.min.js';
 import 'angular-route';
 import 'angular-sanitize';
 import 'angular-cookies';


### PR DESCRIPTION
Importing ovh-ui-angular breaks when code is minified. Reverting to script import waiting for issue to be fixed.