### PR TITLE
fix(2fa): phone number preload

### DIFF
--- a/client/app/account/user/security/2fa/user-security-2fa.controller.js
+++ b/client/app/account/user/security/2fa/user-security-2fa.controller.js
@@ -1,17 +1,17 @@
 angular.module('UserAccount').controller('UserAccount.controllers.doubleAuth.2fa.enable', [
+  '$q',
   '$rootScope',
   '$scope',
-  '$q',
   '$translate',
-  'UserAccount.services.Infos',
+  'Alerter',
   'UserAccount.services.doubleAuth.backupCode',
   'UserAccount.services.doubleAuth.sms',
   'UserAccount.services.doubleAuth.totp',
   'UserAccount.services.doubleAuth.u2f',
-  'Alerter',
-  function ($rootScope, $scope, $q, $translate,
-    UserAccountServiceInfos, DoubleAuthBackupCodeService, DoubleAuthSmsService,
-    DoubleAuthTotpService, DoubleAuthU2fService, Alerter) {
+  'UserAccount.services.Infos',
+  function ($q, $rootScope, $scope, $translate,
+    Alerter, DoubleAuthBackupCodeService, DoubleAuthSmsService,
+    DoubleAuthTotpService, DoubleAuthU2fService, UserAccountServiceInfos) {
     $scope.step1 = {
       doubleAuthType: null,
       isActive: false,

--- a/client/app/account/user/security/2fa/user-security-2fa.controller.js
+++ b/client/app/account/user/security/2fa/user-security-2fa.controller.js
@@ -3,12 +3,14 @@ angular.module('UserAccount').controller('UserAccount.controllers.doubleAuth.2fa
   '$scope',
   '$q',
   '$translate',
+  'UserAccount.services.Infos',
   'UserAccount.services.doubleAuth.backupCode',
   'UserAccount.services.doubleAuth.sms',
   'UserAccount.services.doubleAuth.totp',
   'UserAccount.services.doubleAuth.u2f',
   'Alerter',
-  function ($rootScope, $scope, $q, $translate, DoubleAuthBackupCodeService, DoubleAuthSmsService,
+  function ($rootScope, $scope, $q, $translate,
+    UserAccountServiceInfos, DoubleAuthBackupCodeService, DoubleAuthSmsService,
     DoubleAuthTotpService, DoubleAuthU2fService, Alerter) {
     $scope.step1 = {
       doubleAuthType: null,
@@ -240,6 +242,10 @@ angular.module('UserAccount').controller('UserAccount.controllers.doubleAuth.2fa
       switch ($scope.getDoubleAuthType()) {
         case 'sms':
           // Ask phone number and then send code with `fetchSmsCode` helper.
+          $scope.step2.sms.isLoading = true;
+          if (!$scope.step2.sms.phone) {
+            promises.sms = UserAccountServiceInfos.getUseraccountInfos();
+          }
           break;
         case 'totp':
           // Add a TOTP access restriction.
@@ -261,6 +267,9 @@ angular.module('UserAccount').controller('UserAccount.controllers.doubleAuth.2fa
       return $q
         .all(promises)
         .then((results) => {
+          if (results.sms) {
+            $scope.step2.sms.phone = results.sms.phone || '';
+          }
           if (results.totp) {
             $scope.step2.totp.qrCode = results.totp;
           }
@@ -269,6 +278,7 @@ angular.module('UserAccount').controller('UserAccount.controllers.doubleAuth.2fa
           }
         })
         .finally(() => {
+          $scope.step2.sms.isLoading = false;
           $scope.step2.totp.isLoading = false;
           $scope.step2.u2f.isLoading = false;
         });

--- a/client/app/account/user/security/2fa/user-security-2fa.html
+++ b/client/app/account/user/security/2fa/user-security-2fa.html
@@ -166,7 +166,7 @@
                                         data-ng-disabled="step2.sms.isSendingCode || !step2.sms.phone"
                                         data-translate="user_account_security_double_auth_wizard_sms_send">
                                 </button>
-                                <oui-spinner data-ng-if="step2.sms.isLoading" size="s"></oui-spinner>
+                                <oui-spinner data-ng-if="step2.sms.isLoading" data-size="s"></oui-spinner>
                             </div>
                         </div>
                         <span class="help-block"

--- a/client/app/account/user/security/2fa/user-security-2fa.html
+++ b/client/app/account/user/security/2fa/user-security-2fa.html
@@ -157,14 +157,16 @@
                                    placeholder="{{ 'user_account_security_double_auth_type_sms_modal_add_number_label' | translate }}"
                                    data-ng-model="step2.sms.phone"
                                    data-ng-pattern="/^\+(?:[0-9] ?){6,14}[0-9]$/"
-                                   data-ng-disabled="step2.sms.isSendingCode">
+                                   data-ng-disabled="step2.sms.isSendingCode || step2.sms.isLoading">
                             <div class="input-group-btn">
                                 <button type="button"
                                         class="btn btn-default"
                                         data-ng-click="fetchSmsCode()"
+                                        data-ng-if="!step2.sms.isLoading"
                                         data-ng-disabled="step2.sms.isSendingCode || !step2.sms.phone"
                                         data-translate="user_account_security_double_auth_wizard_sms_send">
                                 </button>
+                                <oui-spinner data-ng-if="step2.sms.isLoading" size="s"></oui-spinner>
                             </div>
                         </div>
                         <span class="help-block"

--- a/client/app/account/user/security/2fa/user-security-2fa.html
+++ b/client/app/account/user/security/2fa/user-security-2fa.html
@@ -446,7 +446,7 @@
                      width="148"
                      height="148">
                 <h2 data-translate="user_account_security_double_auth_wizard_congratulation_title"></h2>
-                <h3 data-translate="user_account_security_double_auth_wizard_congratulation_info1"></h3>
+                <h3 class="font-lite" data-translate="user_account_security_double_auth_wizard_congratulation_info1"></h3>
                 <p data-ng-bind-html="'user_account_security_double_auth_wizard_congratulation_info2' | translate "></p>
             </div>
         </div>

--- a/client/app/account/user/translations/Messages_fr_FR.xml
+++ b/client/app/account/user/translations/Messages_fr_FR.xml
@@ -626,7 +626,7 @@
    <translation id="user_account_security_double_auth_wizard_sms_send" qtlid="52807">Envoyer</translation>
    <translation id="user_account_security_double_auth_wizard_u2f_add_success" qtlid="441164">La clé a été ajoutée avec succès.</translation>
    <translation id="user_account_security_double_auth_wizard_congratulation_title" qtlid="441177">Bravo !</translation>
-   <translation id="user_account_security_double_auth_wizard_congratulation_info1" qtlid="441190">Votre compte est maintenant sécurisé !</translation>
+   <translation id="user_account_security_double_auth_wizard_congratulation_info1">Votre compte est maintenant sécurisé!</translation>
    <translation id="user_account_security_double_auth_wizard_congratulation_info2" qtlid="441203">Pour ajouter d’autres méthodes d’authentification, rendez-vous dans la page <strong>"Sécurité"</strong> de votre compte.</translation>
 
    <translation id="user_account_security_double_auth_type_sms" qtlid="28243">SMS</translation>

--- a/client/app/account/user/translations/Messages_fr_FR.xml
+++ b/client/app/account/user/translations/Messages_fr_FR.xml
@@ -626,7 +626,7 @@
    <translation id="user_account_security_double_auth_wizard_sms_send" qtlid="52807">Envoyer</translation>
    <translation id="user_account_security_double_auth_wizard_u2f_add_success" qtlid="441164">La clé a été ajoutée avec succès.</translation>
    <translation id="user_account_security_double_auth_wizard_congratulation_title" qtlid="441177">Bravo !</translation>
-   <translation id="user_account_security_double_auth_wizard_congratulation_info1">Votre compte est maintenant sécurisé!</translation>
+   <translation id="user_account_security_double_auth_wizard_congratulation_info1" qtlid="441190">Votre compte est maintenant sécurisé !</translation>
    <translation id="user_account_security_double_auth_wizard_congratulation_info2" qtlid="441203">Pour ajouter d’autres méthodes d’authentification, rendez-vous dans la page <strong>"Sécurité"</strong> de votre compte.</translation>
 
    <translation id="user_account_security_double_auth_type_sms" qtlid="28243">SMS</translation>

--- a/client/app/css/source.less
+++ b/client/app/css/source.less
@@ -107,3 +107,7 @@
   max-width: inherit;
   margin-bottom: 0;
 }
+
+h3.font-lite {
+  font-weight: 300;
+}


### PR DESCRIPTION
MANAGER-1335

### Requirements

* In 2FA SMS, the phone number has to be pre-loaded into the phone field, if it is already available
* The last step of 2FA has the exclamation mark alone in the next line.

## 2FA Phone number pre-load

### Description of the Change

* The phone number is pre-loaded now, from the account info
* The exclamation mark going to the next line has been fixed by reducing the font-size applied to the h3 tag (using a new css class)