### PR TITLE
build(deps): upgrade ovh-module-exchange to v9.0.4

### DIFF
--- a/client/app/index.js
+++ b/client/app/index.js
@@ -92,6 +92,9 @@ import 'script-loader!@bower_components/ng-ckeditor/ng-ckeditor.js';
 import 'script-loader!@bower_components/messenger/build/js/messenger.min.js';
 import 'script-loader!flatpickr/dist/flatpickr.min.js';
 
+// Ckeditor 4.x
+import 'script-loader!ng-ckeditor/dist/ng-ckeditor';
+
 import './app.less';
 import './css/source.scss';
 /* eslint-enable import/no-webpack-loader-syntax, import/no-unresolved, import/extensions */

--- a/yarn.lock
+++ b/yarn.lock
@@ -736,11 +736,6 @@
     drange "^1.0.0"
     ret "^0.2.0"
 
-"@ckeditor/ckeditor5-build-classic@^11.0.1":
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-11.1.0.tgz#6269103ba16e1c24e3fbb6c70bec372fedf3cef9"
-  integrity sha512-MjqPVOqbW7HFPAHZyyZGOYyMLkZsqM45d22QlMlKEcwsVSjeR374cUEggOvGdM4B+xSP9pg1PPIIiXubYwwJ3g==
-
 "@commitlint/cli@^7.1.2":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-7.2.0.tgz#04fb5ba1d28bba100a7f71d51d35aa9a8fd5faba"
@@ -7164,10 +7159,9 @@ ovh-manager-webfont@^1.0.2:
   integrity sha1-j501jROMJlClV72sei0ZCOliQY0=
 
 ovh-module-exchange@ovh-ux/ovh-module-exchange#^9.0.0:
-  version "9.0.1"
-  resolved "https://codeload.github.com/ovh-ux/ovh-module-exchange/tar.gz/49bd866609e6e3e33bf163a7384897eb01c520b3"
+  version "9.0.4"
+  resolved "https://codeload.github.com/ovh-ux/ovh-module-exchange/tar.gz/ebf6a39d9be82711b9f83bd7ab70eccca04d87b6"
   dependencies:
-    "@ckeditor/ckeditor5-build-classic" "^11.0.1"
     lodash "~3.9.3"
 
 ovh-ui-angular@^2.19.x:


### PR DESCRIPTION
## ⬆️ Upgrade `ovh-module-exchange` to `v9.0.4`

### Description of the Change

234c021 — build(deps): upgrade ovh-module-exchange to v9.0.4

/cc @jleveugle @frenautvh @cbourgois 