### PR TITLE
feat(kvm-html): kvm html in ipmi tab

### DIFF
--- a/client/app/dedicated/server/ipmi/dedicated-server-ipmi.controller.js
+++ b/client/app/dedicated/server/ipmi/dedicated-server-ipmi.controller.js
@@ -95,8 +95,8 @@ angular.module('App').controller('ImpiCtrl', ($scope, $translate, Server, Pollin
                 (features) => {
                   $scope.kvm.features = features;
                 },
-                (err) => {
-                  Alerter.alertFromSWS($translate.instant('server_configuration_kvm_error'), err.data, $scope.alert);
+                ({ data }) => {
+                  Alerter.alertFromSWS($translate.instant('server_configuration_kvm_error'), data, $scope.alert);
                 },
               )
               .finally(() => {
@@ -132,10 +132,10 @@ angular.module('App').controller('ImpiCtrl', ($scope, $translate, Server, Pollin
         $scope.ipmi.model = results;
         $scope.loader.loading = false;
       },
-      (err) => {
+      (data) => {
         $scope.loader.loading = false;
         $scope.loader.error = true;
-        Alerter.alertFromSWS($translate.instant('server_configuration_impi_loading_error'), err, $scope.alert);
+        Alerter.alertFromSWS($translate.instant('server_configuration_impi_loading_error'), data, $scope.alert);
       },
     );
   }
@@ -198,13 +198,13 @@ angular.module('App').controller('ImpiCtrl', ($scope, $translate, Server, Pollin
       ttl: $scope.ttl,
       ipToAllow: $scope.ipmi.model.clientIp,
     }).then(
-      (task) => {
-        startIpmiPollNavigation({ id: task.taskId });
+      ({ taskId }) => {
+        startIpmiPollNavigation({ id: taskId });
       },
-      (data) => {
+      ({ data }) => {
         $scope.loader.navigationLoading = false;
         $scope.loader.buttonStart = false;
-        Alerter.alertFromSWS($translate.instant('server_configuration_impi_navigation_error'), data.data, $scope.alert);
+        Alerter.alertFromSWS($translate.instant('server_configuration_impi_navigation_error'), data, $scope.alert);
       },
     );
   };
@@ -235,10 +235,10 @@ angular.module('App').controller('ImpiCtrl', ($scope, $translate, Server, Pollin
         window.open(connect.value, '_blank');
         Alerter.alertFromSWS($translate.instant('server_configuration_impi_navigation_success'), true, $scope.alert);
       },
-      (data) => {
+      ({ data }) => {
         $scope.loader.navigationLoading = false;
         $scope.loader.buttonStart = false;
-        Alerter.alertFromSWS($translate.instant('server_configuration_impi_navigation_error'), data.data, $scope.alert);
+        Alerter.alertFromSWS($translate.instant('server_configuration_impi_navigation_error'), data, $scope.alert);
       },
     );
   }
@@ -252,13 +252,13 @@ angular.module('App').controller('ImpiCtrl', ($scope, $translate, Server, Pollin
       ttl: $scope.ttl,
       ipToAllow: $scope.ipmi.model.clientIp,
     }).then(
-      (task) => {
-        startIpmiKvmUrlPoll({ id: task.taskId });
+      ({ taskId }) => {
+        startIpmiKvmUrlPoll({ id: taskId });
       },
-      (err) => {
+      ({ data }) => {
         $scope.loader.kvmhtmlLoading = false;
         $scope.loader.buttonStart = false;
-        Alerter.alertFromSWS($translate.instant('server_configuration_impi_navigation_error'), err.data, $scope.alert);
+        Alerter.alertFromSWS($translate.instant('server_configuration_impi_navigation_error'), data, $scope.alert);
       },
     );
   };
@@ -289,10 +289,10 @@ angular.module('App').controller('ImpiCtrl', ($scope, $translate, Server, Pollin
         $scope.loader.kvmUrl = data.value;
         Alerter.alertFromSWS($translate.instant('server_configuration_impi_navigation_success'), true, $scope.alert);
       },
-      (err) => {
+      ({ data }) => {
         $scope.loader.kvmhtmlLoading = false;
         $scope.loader.buttonStart = false;
-        Alerter.alertFromSWS($translate.instant('server_configuration_impi_navigation_error'), err.data, $scope.alert);
+        Alerter.alertFromSWS($translate.instant('server_configuration_impi_navigation_error'), data, $scope.alert);
       },
     );
   }
@@ -310,13 +310,13 @@ angular.module('App').controller('ImpiCtrl', ($scope, $translate, Server, Pollin
       ipToAllow: $scope.ipmi.model.clientIp,
       withGeolocation,
     }).then(
-      (task) => {
-        startIpmiPollJava({ id: task.taskId });
+      ({ taskId }) => {
+        startIpmiPollJava({ id: taskId });
       },
-      (err) => {
+      (data) => {
         $scope.loader.javaLoading = false;
         $scope.loader.buttonStart = false;
-        Alerter.alertFromSWS($translate.instant('server_configuration_impi_java_error'), err, $scope.alert);
+        Alerter.alertFromSWS($translate.instant('server_configuration_impi_java_error'), data, $scope.alert);
       },
     );
   };

--- a/client/app/dedicated/server/ipmi/dedicated-server-ipmi.html
+++ b/client/app/dedicated/server/ipmi/dedicated-server-ipmi.html
@@ -72,7 +72,7 @@
                         </a>
                     </p>
                     <ul class="list-inline mt-4">
-                        <li class="text-center mb-4"
+                        <li class="text-center mb-4 align-top"
                             data-ng-if="hasSOL()">
                             <button type="button"
                                     class="btn btn-default btn-block d-flex"
@@ -92,7 +92,7 @@
                                data-translate="server_configuration_impi_navigation_go">
                             </a>
                         </li>
-                        <li>
+                        <li class="align-top">
                             <button type="button"
                                     class="btn btn-default btn-block d-flex"
                                     data-ng-click="startIpmiJava()"
@@ -110,7 +110,7 @@
                                     data-translate="server_configuration_impi_java_download">
                             </button>
                         </li>
-                        <li ng-if="ipmi.model.supportedFeatures.kvmipHtml5URL">
+                        <li data-ng-if="ipmi.model.supportedFeatures.kvmipHtml5URL" class="align-top">
                             <button type="button"
                                     class="btn btn-default btn-block d-flex"
                                     data-ng-click="getIpmiKvmUrl()"

--- a/client/app/dedicated/server/ipmi/dedicated-server-ipmi.html
+++ b/client/app/dedicated/server/ipmi/dedicated-server-ipmi.html
@@ -72,7 +72,7 @@
                         </a>
                     </p>
                     <ul class="list-inline mt-4">
-                        <li class="text-center"
+                        <li class="text-center mb-4"
                             data-ng-if="hasSOL()">
                             <button type="button"
                                     class="btn btn-default btn-block"
@@ -109,6 +109,25 @@
                                     data-ng-click="downloadApplet()"
                                     data-translate="server_configuration_impi_java_download">
                             </button>
+                        </li>
+                        <li ng-if="ipmi.model.supportedFeatures.kvmipHtml5URL">
+                            <button type="button"
+                                    class="btn btn-default btn-block"
+                                    data-ng-click="getIpmiKvmUrl()"
+                                    data-ng-disabled="loader.buttonStart || disable.otherTask || disable.localTask">
+                                <span data-translate="server_configuration_impi_kvm_console"></span>
+                                <oui-spinner class="ml-2" 
+                                             data-ng-if="loader.kvmhtmlLoading"
+                                             data-size="s">
+                                </oui-spinner>
+                            </button>
+                            <a class="btn btn-default btn-block"
+                               href="{{ loader.kvmUrl }}"
+                               target="_blank"
+                               rel="noopener"
+                               data-ng-if="loader.kvmUrlReady && !disable.otherTask && !disable.localTask"
+                               data-translate="server_configuration_impi_kvm_url">
+                            </a>
                         </li>
                     </ul>
                 </div>

--- a/client/app/dedicated/server/ipmi/dedicated-server-ipmi.html
+++ b/client/app/dedicated/server/ipmi/dedicated-server-ipmi.html
@@ -75,7 +75,7 @@
                         <li class="text-center mb-4"
                             data-ng-if="hasSOL()">
                             <button type="button"
-                                    class="btn btn-default btn-block"
+                                    class="btn btn-default btn-block d-flex"
                                     data-ng-click="startIpmiNavigation()"
                                     data-ng-disabled="loader.buttonStart || disable.otherTask || disable.localTask">
                                 <span data-translate="server_configuration_impi_navigation"></span>
@@ -94,7 +94,7 @@
                         </li>
                         <li>
                             <button type="button"
-                                    class="btn btn-default btn-block"
+                                    class="btn btn-default btn-block d-flex"
                                     data-ng-click="startIpmiJava()"
                                     data-ng-disabled="loader.buttonStart || disable.otherTask || disable.localTask">
                                 <span data-translate="server_configuration_impi_java"></span>
@@ -112,7 +112,7 @@
                         </li>
                         <li ng-if="ipmi.model.supportedFeatures.kvmipHtml5URL">
                             <button type="button"
-                                    class="btn btn-default btn-block"
+                                    class="btn btn-default btn-block d-flex"
                                     data-ng-click="getIpmiKvmUrl()"
                                     data-ng-disabled="loader.buttonStart || disable.otherTask || disable.localTask">
                                 <span data-translate="server_configuration_impi_kvm_console"></span>

--- a/client/app/dedicated/server/translations/Messages_fr_FR.xml
+++ b/client/app/dedicated/server/translations/Messages_fr_FR.xml
@@ -638,9 +638,11 @@
    <translation id="server_configuration_impi_navigation" qtlid="257296">Depuis votre navigateur (SoL)</translation>
    <translation id="server_configuration_impi_navigation_error" qtlid="164818">Une erreur est survenue lors de la tentative de connexion au module IPMI avec votre navigateur</translation>
    <translation id="server_configuration_impi_navigation_success" qtlid="164831">La connexion au module IPMI avec votre navigateur est prête.</translation>
-   <translation id="server_configuration_impi_navigation_go" qtlid="164844">Accéder à la console</translation>
+   <translation id="server_configuration_impi_navigation_go">Accéder à la console (SOL)</translation>
    <translation id="server_configuration_impi_java" qtlid="257309">Depuis une applet java (KVM)</translation>
    <translation id="server_configuration_impi_java_download" qtlid="164870">Télécharger l'applet java</translation>
+   <translation id="server_configuration_impi_kvm_console">Depuis votre navigateur (KVM)</translation>
+   <translation id="server_configuration_impi_kvm_url">Accéder à la console (KVM)</translation>
    <translation id="server_configuration_impi_java_success" qtlid="164883">La connexion au module IPMI avec une applet java est prête.</translation>
    <translation id="server_configuration_impi_java_error" qtlid="164896">Une erreur est survenue lors de la tentative de connexion au module IPMI avec une applet java</translation>
    <translation id="server_configuration_impi_java_new" qtlid="164909">Nouvelle connexion</translation>


### PR DESCRIPTION
## Add kvm html5 url support to ipmi

### Description of the Change

add button to support kvm html5 url
add url button which opens a new tab
add api calls to support this

### Benefits

Helps user launch kvm in browser

### Possible Drawbacks

None

### Applicable Issues

resolves MANAGER-1368
