### PR TITLE
fix(dedicated.server): installation template error

### DIFF
--- a/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js
+++ b/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js
@@ -1742,7 +1742,7 @@ angular
                 $scope.loader.loading = true;
                 setGabarit();
             } else if ($scope.installation.hardwareRaid.raid) {
-                $scope.installation.options.gabaritNameSave = `tmp-mgr-hardwareRaid-${moment()}`;
+                $scope.installation.options.gabaritNameSave = `tmp-mgr-hardwareRaid-${moment().unix()}`;
                 setGabarit();
             } else {
                 startInstall();


### PR DESCRIPTION
## Installation template name error 400


### Description of the Change

Wrong template name cause API error 400 and blocks installation.

### References
DTRUN-54