### PR TITLE
fix(deps): upgrade ovh-angular-otrs to v6.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "ovh-angular-browser-alert": "ovh-ux/ovh-angular-browser-alert#^1.0.0",
     "ovh-angular-export-csv": "^0.3.2",
     "ovh-angular-http": "^3.0.1",
-    "ovh-angular-otrs": "^6.0.1",
+    "ovh-angular-otrs": "^6.3.0",
     "ovh-angular-pagination-front": "^7.0.0",
     "ovh-angular-proxy-request": "^0.1.0",
     "ovh-angular-q-allsettled": "^0.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7842,10 +7842,10 @@ ovh-angular-http@^3.0.1:
     jquery "~2.1.3"
     lodash "~3.3.0"
 
-ovh-angular-otrs@^6.0.1:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/ovh-angular-otrs/-/ovh-angular-otrs-6.2.2.tgz#825aa6d0f01801bd46568ec19285456749f45cba"
-  integrity sha512-zeaNcQM6bCMAZwItQ5hL3lVkSWAevLk0Rv/LVQXX/MnxYx3TS/MAue0/M64p/FTTlziqZylN0bd9HZ70jOzerw==
+ovh-angular-otrs@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/ovh-angular-otrs/-/ovh-angular-otrs-6.3.0.tgz#3ad3c9626be1917b5f0f557375de3757ad9b08ba"
+  integrity sha512-sXxQUlsC0ucl9UVcnSB9ZQsqTnKmW/zQZM+VH0gNpnJo9v3Klk4lHN3n0Wnd62Ic8Ke3Vjgk74Jk2THjQOHfcg==
 
 ovh-angular-pagination-front@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
## ⬆️ upgrade `ovh-angular-otrs` to `v6.3.0`

### Description of the Change

bd72db1 — fix(deps): upgrade ovh-angular-otrs to v6.3.0

/cc @jleveugle @frenautvh @cbourgois 