### PR TITLE
fix(deps): upgrade ovh-module-exchange to v9.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "ovh-api-services": "^3.5.0",
     "ovh-jquery-ui-draggable-ng": "^0.0.5",
     "ovh-manager-webfont": "^1.0.2",
-    "ovh-module-exchange": "ovh-ux/ovh-module-exchange#^9.0.0",
+    "ovh-module-exchange": "^9.0.5",
     "ovh-ui-angular": "^2.22.x",
     "ovh-ui-kit": "^2.22.x",
     "ovh-ui-kit-bs": "~1.3.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7919,9 +7919,10 @@ ovh-manager-webfont@^1.0.2:
   resolved "https://registry.yarnpkg.com/ovh-manager-webfont/-/ovh-manager-webfont-1.0.2.tgz#8f9d358d138c2650a557bdac7a2d1908e962418d"
   integrity sha1-j501jROMJlClV72sei0ZCOliQY0=
 
-ovh-module-exchange@ovh-ux/ovh-module-exchange#^9.0.0:
-  version "9.0.4"
-  resolved "https://codeload.github.com/ovh-ux/ovh-module-exchange/tar.gz/ebf6a39d9be82711b9f83bd7ab70eccca04d87b6"
+ovh-module-exchange@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/ovh-module-exchange/-/ovh-module-exchange-9.0.5.tgz#e6d1d2ce2ae4c39c481c5320726c583b287f2355"
+  integrity sha512-BM4h2GLxWC81O9PB9WN2rCw/y6zkL4p0vzo2DenORGOe0pMhso/N7fu2pFWMaMJnOVxDGWZyEOcxmp/BnEa8iA==
   dependencies:
     lodash "~3.9.3"
 


### PR DESCRIPTION
## ⬆️ upgrade `ovh-module-exchange` to `v9.0.5`

### Description of the Change

ab95748 — fix(deps): upgrade ovh-module-exchange to v9.0.5

/cc @jleveugle @frenautvh @cbourgois 