### PR TITLE
fix(billing): search text capture from url

### DIFF
--- a/client/app/account/billing/autoRenew/billing-autoRenew.controller.js
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.controller.js
@@ -705,12 +705,12 @@ angular.module('Billing.controllers').controller('Billing.controllers.AutoRenew'
       $scope.initLoading = true;
 
       const {
-        selectedType, searchTextValue, renewFilter, renewalFilter, order,
+        selectedType, searchText, renewFilter, renewalFilter, order,
       } = $location.search();
 
       $scope.services.selectedType = selectedType;
       $scope.searchText = {
-        value: searchTextValue,
+        value: searchText,
       };
       $scope.renewFilter.model = renewFilter === '0' ? 0 : renewFilter || 0;
       $scope.renewalFilter.model = renewalFilter === '0' ? '0' : renewalFilter || '0';


### PR DESCRIPTION
Close MBE-163

### Requirements

The searchText Param that can be passed to the billing > autorenew page is not being picked up

## Search text capture from url


### Description of the Change

The searchText was being picked from the wrong parameter (param name was wrong). This has been corrected.