### PR TITLE
fix(ip): add port redirection

### DIFF
--- a/client/app/ip/ip-lb/ip-ip-lb.html
+++ b/client/app/ip/ip-lb/ip-ip-lb.html
@@ -288,6 +288,7 @@
         <button type="button"
                 class="btn btn-primary"
                 data-ng-click="setAction('ip-lb/redirection/add/ip-ip-lb-redirection-add', selectedIplb)"
+                data-ng-disabled="!(iplbList.length > 0)"
                 data-translate="iplb_portsredirection_add_title">
         </button>
         <div class="table-responsive mt-2">

--- a/client/app/ip/ip-lb/ip-ip-lb.html
+++ b/client/app/ip/ip-lb/ip-ip-lb.html
@@ -288,7 +288,7 @@
         <button type="button"
                 class="btn btn-primary"
                 data-ng-click="setAction('ip-lb/redirection/add/ip-ip-lb-redirection-add', selectedIplb)"
-                data-ng-disabled="!(iplbList.length > 0)"
+                data-ng-disabled="!iplbList.length"
                 data-translate="iplb_portsredirection_add_title">
         </button>
         <div class="table-responsive mt-2">


### PR DESCRIPTION
Close MBE-61

### Requirements

The Add port redirection button opens a dialog that keeps loading forever, This should be fixed

## Disable Add Port Redirection


### Description of the Change

The Add port redirection button has to be disabled when the number of load balancer services is 0, to fix this issue. This has been done.