### PR TITLE
fix(dedicated-server): tabs loading

### DIFF
--- a/client/app/dedicated/server/dedicated-server-tabs.controller.js
+++ b/client/app/dedicated/server/dedicated-server-tabs.controller.js
@@ -14,8 +14,6 @@ angular.module('App').controller('ServerTabsCtrl', ($scope, $stateParams, $locat
     .pull(featureAvailability.allowDedicatedServerUSBKeys() ? null : 'usb_storage')
     .value();
 
-  $scope.tabs = originalTabs;
-
   $scope.setSelectedTab = function (tab) {
     if (tab !== undefined && tab !== null && tab !== '') {
       $scope.selectedTab = tab;
@@ -32,10 +30,12 @@ angular.module('App').controller('ServerTabsCtrl', ($scope, $stateParams, $locat
   }
 
   $scope.$on('dedicated.server.refreshTabs', () => {
-    $scope.tabs = originalTabs;
+    if (!$scope.server.notLoaded) {
+      $scope.tabs = originalTabs;
 
-    if ($scope.server.commercialRange === 'housing') {
-      $scope.tabs = ['dashboard', 'dns', 'ftp_backup', 'intervention', 'task'];
+      if ($scope.server.commercialRange === 'housing') {
+        $scope.tabs = ['dashboard', 'dns', 'ftp_backup', 'intervention', 'task'];
+      }
     }
   });
 });

--- a/client/app/dedicated/server/dedicated-server.controller.js
+++ b/client/app/dedicated/server/dedicated-server.controller.js
@@ -7,6 +7,7 @@ angular.module('App').controller('ServerCtrl', (NO_AUTORENEW_COUNTRIES, WEATHERM
   $scope.featureAvailability = featureAvailability;
   $scope.server = {
     isExpired: true,
+    notLoaded: true,
   };
 
   $scope.loaders = {

--- a/client/app/dedicated/server/dedicated-server.html
+++ b/client/app/dedicated/server/dedicated-server.html
@@ -19,7 +19,12 @@
             </div>
             <p data-ng-bind="server.reverse || ('server_configuration_reverse_not_configured' | translate)"></p>
         </header>
+        <div class="text-center mt-5"
+            data-ng-if="!tabs">
+            <oui-spinner data-size="l"></oui-spinner>
+        </div>
         <ovh-tabs data-tabs="tabs"
+                  data-ng-if="tabs"
                   data-selected-tab="selectedTab"
                   data-product="server"
                   data-change-tab="setSelectedTab"


### PR DESCRIPTION
Close MBP-148

### Requirements

While loading a dedicated server, some additional tabs are seen for a couple of seconds, before the correct set of tabs are shown. This has to be fixed.

## Tab Loading fix for Dedicated Server


### Description of the Change

This issue has been fixed by showing the tabs only after the correct set of tabs have been loaded.