### PR TITLE
fix(account): country code update

### DIFF
--- a/client/app/account/user/contacts/update/user-contacts-update.controller.js
+++ b/client/app/account/user/contacts/update/user-contacts-update.controller.js
@@ -124,7 +124,7 @@ angular.module('UserAccount').controller('UserAccount.controllers.update', [
             $scope.controls.legalforms = legalforms;
           }),
           Contacts.getCountryEnum().then((countries) => {
-            $scope.controls.countries = countries;
+            $scope.controls.countries = _.reject(countries, country => country === 'UNKNOWN');
           }),
           Contacts.getGendersEnum().then((genders) => {
             $scope.controls.genders = genders;

--- a/client/app/account/user/contacts/update/user-contacts-update.controller.js
+++ b/client/app/account/user/contacts/update/user-contacts-update.controller.js
@@ -124,7 +124,7 @@ angular.module('UserAccount').controller('UserAccount.controllers.update', [
             $scope.controls.legalforms = legalforms;
           }),
           Contacts.getCountryEnum().then((countries) => {
-            $scope.controls.countries = _.reject(countries, country => country === 'UNKNOWN');
+            $scope.controls.countries = countries.filter(country => country !== 'UNKNOWN');
           }),
           Contacts.getGendersEnum().then((genders) => {
             $scope.controls.genders = genders;

--- a/client/app/common/translations/Messages_fr_FR.xml
+++ b/client/app/common/translations/Messages_fr_FR.xml
@@ -217,6 +217,7 @@
    <translation id="price_free" qtlid="195776">Inclus</translation>
    <translation id="price_label_yearly" qtlid="288977">/an</translation>
 
+   <translation id="country_AC">Île D'Ascension</translation>
    <translation id="country_AD" qtlid="43510">Andorre</translation>
    <translation id="country_AE" qtlid="187014">Émirats Arabes Unis</translation>
    <translation id="country_AF" qtlid="172683">Afghanistan</translation>
@@ -225,6 +226,7 @@
    <translation id="country_AL" qtlid="43798">Albanie</translation>
    <translation id="country_AM" qtlid="187053">Arménie</translation>
    <translation id="country_AO" qtlid="187066">Angola</translation>
+   <translation id="country_AQ">Antarctique</translation>
    <translation id="country_AR" qtlid="187079">Argentine</translation>
    <translation id="country_AS" qtlid="187092">Samoa Américaines</translation>
    <translation id="country_AT" qtlid="43570">Autriche</translation>
@@ -272,11 +274,13 @@
    <translation id="country_CY" qtlid="43810">Chypre</translation>
    <translation id="country_CZ" qtlid="40918">République tchèque</translation>
    <translation id="country_DE" qtlid="29083">Allemagne</translation>
+   <translation id="country_DG">Diego Garcia</translation>
    <translation id="country_DJ" qtlid="187560">Djibouti</translation>
    <translation id="country_DK" qtlid="187573">Danemark</translation>
    <translation id="country_DM" qtlid="187586">Dominique</translation>
    <translation id="country_DO" qtlid="187599">Dominicaine, République</translation>
    <translation id="country_DZ" qtlid="187612">Algérie</translation>
+   <translation id="country_EA">Ceuta, Melilla</translation>
    <translation id="country_EC" qtlid="187625">Équateur</translation>
    <translation id="country_EE" qtlid="43630">Estonie</translation>
    <translation id="country_EG" qtlid="187638">Égypte</translation>
@@ -314,6 +318,7 @@
    <translation id="country_HR" qtlid="43690">Croatie</translation>
    <translation id="country_HT" qtlid="187989">Haïti</translation>
    <translation id="country_HU" qtlid="188002">Hongrie</translation>
+   <translation id="country_IC">Les Îles Canaries</translation>
    <translation id="country_ID" qtlid="188015">Indonésie</translation>
    <translation id="country_IE" qtlid="104878">Irlande</translation>
    <translation id="country_IL" qtlid="188028">Israël</translation>
@@ -428,6 +433,7 @@
    <translation id="country_SX" qtlid="189198">Saint-Martin (Royaume des Pays-Bas)</translation>
    <translation id="country_SY" qtlid="189211">Syrienne, République Arabe</translation>
    <translation id="country_SZ" qtlid="189224">Swaziland</translation>
+   <translation id="country_TA">Tristan da Cunha</translation>
    <translation id="country_TC" qtlid="189237">Turks Et Caïques, Îles</translation>
    <translation id="country_TD" qtlid="189250">Tchad</translation>
    <translation id="country_TF" qtlid="189263">Terres Australes Françaises</translation>
@@ -460,6 +466,7 @@
    <translation id="country_VU" qtlid="189562">Vanuatu</translation>
    <translation id="country_WF" qtlid="189575">Wallis Et Futuna</translation>
    <translation id="country_WS" qtlid="189588">Samoa</translation>
+   <translation id="country_XK">Kosovo</translation>
    <translation id="country_YE" qtlid="189601">Yémen</translation>
    <translation id="country_YT" qtlid="189614">Mayotte</translation>
    <translation id="country_ZA" qtlid="189627">Afrique Du Sud</translation>


### PR DESCRIPTION
Close MBP-136

### Requirements

In the Accounts updated section, the Nationalité drop-down shows country_Code for some countries. This has to be fixed.

## Country code update


### Description of the Change

This has been fixed by adding corresponding translations for the country codes. The Unknown country has been removed.