### PR TITLE
fix(dedicatedcloud): restore dashboard alert

### DIFF
--- a/client/app/dedicatedCloud/dedicatedCloud.controller.js
+++ b/client/app/dedicatedCloud/dedicatedCloud.controller.js
@@ -31,6 +31,7 @@ angular.module('App').controller('DedicatedCloudCtrl', [
   ) {
     $scope.HDS_READY_NOTIFICATION = 'HDS_READY_NOTIFICATION';
 
+    $scope.alerts = { dashboard: 'dedicatedCloud_alert' };
     $scope.loadingInformations = true;
     $scope.loadingError = false;
     $scope.dedicatedCloud = null;


### PR DESCRIPTION
## fix(dedicatedcloud): restore dashboard alert
 
### Description of the Change

3a2168ad - fix(dedicatedcloud): restore dashboard alert

Bug introduced in https://github.com/ovh-ux/ovh-manager-dedicated/commit/8908736d8d0434086153101e15f2b74a92ebcfa6#diff-9267478398e5c416519431952cdec4a8L34 

ref:

/cc @jleveugle @frenautvh @antleblanc

