### PR TITLE
fix(server): mrtg chart labels

### DIFF
--- a/client/app/dedicated/server/statistics/dedicated-server-statistics.controller.js
+++ b/client/app/dedicated/server/statistics/dedicated-server-statistics.controller.js
@@ -72,9 +72,7 @@ angular.module('controllers').controller('controllers.Server.Stats', (
     $scope.data = [];
 
     $scope.labels = _.map(_.get(data, 'download.values'), (value, index) => moment(data.download.pointStart)
-      .add(data.download.pointInterval.standardDays * index, 'days')
-      .add(data.download.pointInterval.standardHours * index, 'hours')
-      .add(data.download.pointInterval.standardMinutes * index, 'minutes')
+      .add(data.download.pointInterval.millis * index, 'milliseconds')
       .calendar());
 
     $scope.series.push($translate.instant('server_tab_STATS_legend_download'));


### PR DESCRIPTION
Close MBP-20

### Requirements

For the month chart, the ending date is being offset by 1 month.

## MRTG Chart Labels fix


### Description of the Change

This issue was happening because, the offset from the start date was being done 3 times. This has been fixed by calculating label for each point by adding only the milliseconds offet.