### PR TITLE
build(deps): upgrade ovh-module-exchange to v9.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "ovh-api-services": "^3.30.0",
     "ovh-jquery-ui-draggable-ng": "^0.0.5",
     "ovh-manager-webfont": "^1.0.2",
-    "ovh-module-exchange": "^9.2.3",
+    "ovh-module-exchange": "^9.2.4",
     "ovh-ui-angular": "^2.24.0",
     "ovh-ui-kit": "^2.24.0",
     "ovh-ui-kit-bs": "~1.3.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7717,10 +7717,10 @@ ovh-manager-webfont@^1.0.2:
   resolved "https://registry.yarnpkg.com/ovh-manager-webfont/-/ovh-manager-webfont-1.0.2.tgz#8f9d358d138c2650a557bdac7a2d1908e962418d"
   integrity sha1-j501jROMJlClV72sei0ZCOliQY0=
 
-ovh-module-exchange@^9.2.3:
-  version "9.2.3"
-  resolved "https://registry.yarnpkg.com/ovh-module-exchange/-/ovh-module-exchange-9.2.3.tgz#c1481a0d52eb3642c544b94bde740be2548ba58a"
-  integrity sha512-vHcxg0JWtYdds+/q7xd6niWQyxciZlXvNmg+0gtH3a2nNfK77wpI19M+VaeBWNHSzS49+/dXvR8NHFeAQw+ZJQ==
+ovh-module-exchange@^9.2.4:
+  version "9.2.4"
+  resolved "https://registry.yarnpkg.com/ovh-module-exchange/-/ovh-module-exchange-9.2.4.tgz#791a216ec3fa7229db0f0819d35401d3481bd8e0"
+  integrity sha512-l0hTM7Pri2pRvnAEuqFY4H99YYi3bqFX+KhUwAN+YnHj5szB2tgimhyW86JX5M4t9HWvJ+hugEvIUTajjcClnQ==
   dependencies:
     filesize "^3.6.1"
     lodash "~3.9.3"


### PR DESCRIPTION
## Upgrade `ovh-module-exchange` to `v9.2.4`

### Description of the Change

#### :arrow_up: Module Exchange v9.2.4

MANAGER-737 - fix: export email as .pst time not valid