### PR TITLE
fix(deps): upgrade exchange module

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "ovh-api-services": "^3.30.0",
     "ovh-jquery-ui-draggable-ng": "^0.0.5",
     "ovh-manager-webfont": "^1.0.2",
-    "ovh-module-exchange": "^9.3.1",
+    "ovh-module-exchange": "^9.3.2",
     "ovh-ui-angular": "^2.24.0",
     "ovh-ui-kit": "^2.24.0",
     "ovh-ui-kit-bs": "~1.3.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7719,10 +7719,10 @@ ovh-manager-webfont@^1.0.2:
   resolved "https://registry.yarnpkg.com/ovh-manager-webfont/-/ovh-manager-webfont-1.0.2.tgz#8f9d358d138c2650a557bdac7a2d1908e962418d"
   integrity sha1-j501jROMJlClV72sei0ZCOliQY0=
 
-ovh-module-exchange@^9.3.1:
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/ovh-module-exchange/-/ovh-module-exchange-9.3.1.tgz#a2c353c1ab64699d0785acc0add0615fe165d8aa"
-  integrity sha512-P+zXeRYgm1QzJoWmalq6ZWXAloCPS6FRyr+MQUJ5v0y75HdXJ9Ye9BGD8XYkxSHjayZXdSXzFdPve29DxSvb6w==
+ovh-module-exchange@^9.3.2:
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/ovh-module-exchange/-/ovh-module-exchange-9.3.2.tgz#3631f56c7f3ec2aa4fe1758ce567c9e84b48f866"
+  integrity sha512-OYV8A13lfUx7R65kWL0O8HxDpwyqEdmkfe2Vi+i3lmMPjGGA7TV2Mg3M0E2HxDH/CQ3PYsC+VbwB7Tl6GIB2xQ==
   dependencies:
     filesize "^3.6.1"
     lodash "~3.9.3"


### PR DESCRIPTION
# Upgrade `ovh-module-exchange`

### 🐛 Bug Fix

MBP-318 - fix(account.update): display correct label next to the data

uses: yarn upgrade-interactive --latest
- ovh-module-exchange@9.3.2