### PR TITLE
fix(server-mrtg): error on graph data load

### DIFF
--- a/client/app/dedicated/server/statistics/dedicated-server-statistics.controller.js
+++ b/client/app/dedicated/server/statistics/dedicated-server-statistics.controller.js
@@ -87,6 +87,7 @@ angular.module('controllers').controller('controllers.Server.Stats', (
   $scope.loadStatistics = function () {
     const nameServer = null;
     $scope.serverStatsLoad.loading = true;
+    $scope.serverStatsLoad.error = false;
     const promises = {
       interfaces: Server.getNetworkInterfaces($stateParams.productId),
       statConst: Server.getStatisticsConst(),
@@ -161,6 +162,7 @@ angular.module('controllers').controller('controllers.Server.Stats', (
 
   $scope.getStatistics = function () {
     $scope.serverStatsLoad.loading = true;
+    $scope.serverStatsLoad.error = false;
     Server.getStatistics($stateParams.productId, $scope.serverStats.networkChoice, $scope.serverStats.typeChoice, $scope.serverStats.periodeChoice)
       .then((statistics) => {
         $scope.serverStats.model = statistics;


### PR DESCRIPTION
MBP-19

### Requirements

The MRTG graph shows an error sometimes, even if the required data is fetched with a 200 response.

## MRTG Graph Error Fix

### Description of the Change

The issue was happening because the error flag is not being reset to false in the next data fetch, after an error has really occurred. This has been fixed by resetting the error flag at the beginning of a data fetch.