### PR TITLE
fix(deps): upgrade ovh-module-exchange to v9.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "postversion": "git push && git push --tags"
   },
   "dependencies": {
+    "@bower_components/angular-scroll-glue": "Luegg/angularjs-scroll-glue#^2.2.0",
     "@bower_components/angular-ui-utils": "angular-ui/ui-utils#~0.2.3",
     "@bower_components/angular-ui-validate": "angular-ui/ui-validate#~1.2.2",
     "@bower_components/bootstrap-datetimepicker": "tarruda/bootstrap-datetimepicker#~0.0.11",
@@ -46,7 +47,6 @@
     "@bower_components/ng-ckeditor": "esvit/ng-ckeditor#^0.2.1",
     "@bower_components/ng-slide-down": "TheRusskiy/ng-slide-down#^1.0.0",
     "@bower_components/ovh-angular-browser-alert": "ovh-ux/ovh-angular-browser-alert#^1.0.0",
-    "@bower_components/angular-scroll-glue": "Luegg/angularjs-scroll-glue#^2.2.0",
     "@bower_components/qrcode": "janantala/qrcode.js#~1.0.x",
     "@bower_components/randexp": "fent/randexp.js#~0.4.0",
     "@ovh-ux/ng-ovh-apiv7": "^2.0.0",
@@ -123,7 +123,7 @@
     "ovh-api-services": "^4.2.0",
     "ovh-jquery-ui-draggable-ng": "^0.0.5",
     "ovh-manager-webfont": "^1.0.2",
-    "ovh-module-exchange": "^9.3.2",
+    "ovh-module-exchange": "^9.3.3",
     "ovh-ui-angular": "^2.24.0",
     "ovh-ui-kit": "^2.24.0",
     "ovh-ui-kit-bs": "~1.3.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7730,10 +7730,10 @@ ovh-manager-webfont@^1.0.2:
   resolved "https://registry.yarnpkg.com/ovh-manager-webfont/-/ovh-manager-webfont-1.0.2.tgz#8f9d358d138c2650a557bdac7a2d1908e962418d"
   integrity sha1-j501jROMJlClV72sei0ZCOliQY0=
 
-ovh-module-exchange@^9.3.2:
-  version "9.3.2"
-  resolved "https://registry.yarnpkg.com/ovh-module-exchange/-/ovh-module-exchange-9.3.2.tgz#3631f56c7f3ec2aa4fe1758ce567c9e84b48f866"
-  integrity sha512-OYV8A13lfUx7R65kWL0O8HxDpwyqEdmkfe2Vi+i3lmMPjGGA7TV2Mg3M0E2HxDH/CQ3PYsC+VbwB7Tl6GIB2xQ==
+ovh-module-exchange@^9.3.3:
+  version "9.3.3"
+  resolved "https://registry.yarnpkg.com/ovh-module-exchange/-/ovh-module-exchange-9.3.3.tgz#4d889483db8fcd1d6bb388520f037ada8030b1d9"
+  integrity sha512-vec/dBj463gEDcNA+TXVCeeHLnqV3SNTsjioXlDRKJXcS1Z42NfMjyoIu/E6cOvKrT87mYT6cr0Qc9yrbIcedw==
   dependencies:
     filesize "^3.6.1"
     lodash "~3.9.3"


### PR DESCRIPTION
# Upgrade `ovh-module-exchange` to `v9.3.3`

### ⬆️ Upgrade

2e07bf1 - fix(deps): upgrade ovh-module-exchange to v9.3.3

uses: yarn upgrade-interactive --latest
- ovh-module-exchange@9.3.3