### PR TITLE
fix(usage): RTM usage chart

### DIFF
--- a/client/app/cdn/dedicated/domain/statistics/cdn-dedicated-domain-statistics.controller.js
+++ b/client/app/cdn/dedicated/domain/statistics/cdn-dedicated-domain-statistics.controller.js
@@ -4,6 +4,34 @@ angular.module('App').controller('CdnDomainStatisticsCtrl', ($scope, $stateParam
   $scope.loadingStats = false;
   $scope.loadingConsts = false;
 
+  $scope.options = {
+    scales: {
+      yAxes: [{
+        ticks: {
+          min: 0,
+        },
+        scaleLabel: {
+          display: true,
+          labelString: $translate.instant('unit_size_GB'),
+        },
+      }],
+    },
+  };
+
+  $scope.requestOptions = {
+    scales: {
+      yAxes: [{
+        ticks: {
+          min: 0,
+        },
+        scaleLabel: {
+          display: true,
+          labelString: $translate.instant('cdn_statistics_requests_per_second'),
+        },
+      }],
+    },
+  };
+
   function createChart(data) {
     $scope.series = [];
     $scope.data = [];
@@ -16,8 +44,13 @@ angular.module('App').controller('CdnDomainStatisticsCtrl', ($scope, $stateParam
     });
     $scope.series.push($translate.instant(`cdn_stats_legend_${$scope.model.dataType.toLowerCase()}_cdn`));
     $scope.series.push($translate.instant(`cdn_stats_legend_${$scope.model.dataType.toLowerCase()}_backend`));
-    $scope.data.push(_.map(_.get(data, 'cdn.values'), value => value.y));
-    $scope.data.push(_.map(_.get(data, 'backend.values'), value => value.y));
+    if ($scope.model.dataType === 'REQUEST') {
+      $scope.data.push(_.map(_.get(data, 'cdn.values'), value => value.y));
+      $scope.data.push(_.map(_.get(data, 'backend.values'), value => value.y));
+    } else if ($scope.model.dataType === 'BANDWIDTH' || $scope.model.dataType === 'QUOTA') {
+      $scope.data.push(_.map(_.get(data, 'cdn.values'), value => value.y / 1000000000)); // convert B to GB
+      $scope.data.push(_.map(_.get(data, 'backend.values'), value => value.y / 1000000000));
+    }
   }
 
   $scope.getStatistics = () => {

--- a/client/app/cdn/dedicated/domain/statistics/cdn-dedicated-domain-statistics.html
+++ b/client/app/cdn/dedicated/domain/statistics/cdn-dedicated-domain-statistics.html
@@ -82,16 +82,11 @@
     </div>
 
     <div class="text-center"
-         data-ng-show="loadingConsts">
+         data-ng-if="loadingConsts">
         <oui-spinner></oui-spinner>
     </div>
-    <div data-ng-hide="loadingConsts">
-        <div class="text-center"
-             data-ng-show="loadingStats">
-            <oui-spinner></oui-spinner>
-        </div>
-        <div class="oui-box mb-5"
-             data-ng-hide="loadingStats">
+    <div data-ng-if="!loadingConsts">
+        <div class="oui-box mb-5">
             <div class="row">
                 <div class="col-sm-6">
                     <label for="dataType"
@@ -127,12 +122,27 @@
                 </div>
             </div>
         </div>
-        <canvas id="cdnDomainStatsChart"
-                class="chart chart-line"
-                data-ng-hide="loadingStats"
-                data-chart-labels="labels"
-                data-chart-series="series"
-                data-chart-data="data">
-        </canvas>
+        <div class="text-center"
+            data-ng-if="loadingConsts || loadingStats">
+            <oui-spinner></oui-spinner>
+        </div>
+        <div data-ng-if="!loadingConsts && !loadingStats">
+            <canvas id="cdnDomainStatsChart"
+                    class="chart chart-line"
+                    data-chart-labels="labels"
+                    data-chart-series="series"
+                    data-chart-data="data"
+                    data-chart-options="options"
+                    data-ng-if="model.dataType === 'BANDWIDTH' || model.dataType === 'QUOTA'">
+            </canvas>
+            <canvas id="cdnDomainStatsChartRequests"
+                    class="chart chart-line"
+                    data-chart-labels="labels"
+                    data-chart-series="series"
+                    data-chart-data="data"
+                    data-chart-options="requestOptions"
+                    data-ng-if="model.dataType === 'REQUEST'">
+            </canvas>
+        </div>
     </div>
 </div>

--- a/client/app/cdn/dedicated/manage/statistics/cdn-dedicated-manage-statistics.controller.js
+++ b/client/app/cdn/dedicated/manage/statistics/cdn-dedicated-manage-statistics.controller.js
@@ -3,6 +3,33 @@ angular.module('App').controller('CdnStatisticsCtrl', ($scope, $stateParams, $tr
   $scope.consts = null;
   $scope.loadingStats = false;
   $scope.loadingConsts = false;
+  $scope.options = {
+    scales: {
+      yAxes: [{
+        ticks: {
+          min: 0,
+        },
+        scaleLabel: {
+          display: true,
+          labelString: $translate.instant('unit_size_GB'),
+        },
+      }],
+    },
+  };
+
+  $scope.requestOptions = {
+    scales: {
+      yAxes: [{
+        ticks: {
+          min: 0,
+        },
+        scaleLabel: {
+          display: true,
+          labelString: $translate.instant('cdn_statistics_requests_per_second'),
+        },
+      }],
+    },
+  };
 
   function createChart(data) {
     $scope.series = [];
@@ -16,8 +43,13 @@ angular.module('App').controller('CdnStatisticsCtrl', ($scope, $stateParams, $tr
     });
     $scope.series.push($translate.instant(`cdn_stats_legend_${$scope.model.dataType.toLowerCase()}_cdn`));
     $scope.series.push($translate.instant(`cdn_stats_legend_${$scope.model.dataType.toLowerCase()}_backend`));
-    $scope.data.push(_.map(_.get(data, 'cdn.values'), value => value.y));
-    $scope.data.push(_.map(_.get(data, 'backend.values'), value => value.y));
+    if ($scope.model.dataType === 'REQUEST') {
+      $scope.data.push(_.map(_.get(data, 'cdn.values'), value => value.y));
+      $scope.data.push(_.map(_.get(data, 'backend.values'), value => value.y));
+    } else if ($scope.model.dataType === 'BANDWIDTH' || $scope.model.dataType === 'QUOTA') {
+      $scope.data.push(_.map(_.get(data, 'cdn.values'), value => value.y / 1000000000)); // convert B to GB
+      $scope.data.push(_.map(_.get(data, 'backend.values'), value => value.y / 1000000000));
+    }
   }
 
   $scope.getStatistics = () => {

--- a/client/app/cdn/dedicated/manage/statistics/cdn-dedicated-manage-statistics.html
+++ b/client/app/cdn/dedicated/manage/statistics/cdn-dedicated-manage-statistics.html
@@ -236,12 +236,23 @@
              data-ng-if="loadingStats">
             <oui-spinner></oui-spinner>
         </div>
-        <canvas id="cdnStatsChart"
-                class="chart chart-line"
-                data-ng-hide="loadingStats"
-                data-chart-labels="labels"
-                data-chart-series="series"
-                data-chart-data="data">
-        </canvas>
+        <div data-ng-if="!loadingStats">
+            <canvas id="cdnStatsChart"
+                    class="chart chart-line"
+                    data-chart-labels="labels"
+                    data-chart-series="series"
+                    data-chart-data="data"
+                    data-chart-options="options"
+                    data-ng-if="model.dataType === 'BANDWIDTH' || model.dataType === 'QUOTA'">
+            </canvas>
+            <canvas id="cdnStatsChartRequests"
+                    class="chart chart-line"
+                    data-chart-labels="labels"
+                    data-chart-series="series"
+                    data-chart-data="data"
+                    data-chart-options="requestOptions"
+                    data-ng-if="model.dataType === 'REQUEST'">
+            </canvas>
+        </div>
     </div>
 </div>

--- a/client/app/cdn/dedicated/translations/Messages_fr_FR.xml
+++ b/client/app/cdn/dedicated/translations/Messages_fr_FR.xml
@@ -293,4 +293,5 @@
    <translation id="cdn_statistics_period_MONTH" qtlid="99632">30 derniers jours</translation>
    <translation id="cdn_statistics_period_WEEK" qtlid="126856">7 derniers jours</translation>
    <translation id="cdn_configuration_cacherules_upgrade_subscribed" qtlid="499842">Votre service est déjà configuré avec cette option</translation>
+   <translation id="cdn_statistics_requests_per_second">Requêtes par seconde</translation>
 </translations>

--- a/client/app/dedicated/server/statistics/rtm/ServerStatsRtmGeneralController.js
+++ b/client/app/dedicated/server/statistics/rtm/ServerStatsRtmGeneralController.js
@@ -1,15 +1,39 @@
-angular.module('controllers').controller('controllers.Server.Stats.Rtm.General', ($scope, $timeout, $location, $stateParams, Server) => {
+angular.module('controllers').controller('controllers.Server.Stats.Rtm.General', (
+  $scope, $translate, $stateParams, Server,
+) => {
   $scope.loading = true;
   $scope.labels = null;
   $scope.data = null;
+  $scope.options = {
+    scales: {
+      yAxes: [{
+        ticks: {
+          max: 100,
+          min: 0,
+        },
+        scaleLabel: {
+          display: true,
+          labelString: $translate.instant('server_usage_chart_yaxis_label'),
+        },
+      }],
+      xAxes: [{
+        type: 'time',
+        scaleLabel: {
+          display: true,
+          labelString: $translate.instant('server_usage_chart_xaxis_label'),
+        },
+      }],
+    },
+  };
 
   function init() {
+    $scope.loading = true;
     Server.getStatisticsChart($stateParams.productId, {
       period: $scope.selectedPeriod.value,
       type: $scope.rtmOptions.value.data.type,
     }).then((stats) => {
-      $scope.labels = _.map(stats.points, point => _.first(moment.unix(point).format()));
-      $scope.data = _.map(stats.points, point => _.last(point));
+      $scope.labels = _.map(stats.points, point => new Date(_.first(point)));
+      $scope.data = _.map(stats.points, point => _.round(_.last(point), 2));
     }).finally(() => {
       $scope.loading = false;
     });

--- a/client/app/dedicated/server/statistics/rtm/load-avg/dedicated-server-statistics-rtm-load-avg.controller.js
+++ b/client/app/dedicated/server/statistics/rtm/load-avg/dedicated-server-statistics-rtm-load-avg.controller.js
@@ -84,14 +84,11 @@ angular.module('controllers').controller('controllers.Server.Stats.Loadavg', ($s
     $scope.loading = true;
     Server.getStatisticsLoadavg($stateParams.productId, {
       period: $scope.selectedPeriod.value,
-    }).then(
-      (data) => {
-        $scope.chartData = buildChart(data);
-      },
-      () => {
-        $scope.loading = false;
-      },
-    );
+    }).then((data) => {
+      $scope.chartData = buildChart(data);
+    }).finally(() => {
+      $scope.loading = false;
+    });
   }
 
   init();

--- a/client/app/dedicated/server/translations/Messages_fr_FR.xml
+++ b/client/app/dedicated/server/translations/Messages_fr_FR.xml
@@ -1235,4 +1235,6 @@
    <translation id="server_datacenter_SYD_1" qtlid="523242">Sydney (SYD1) - Australie</translation>
    <translation id="server_datacenter_VIN_1" qtlid="523255">Vint Hill (VIN1) - États-Unis</translation>
    <translation id="server_datacenter_WAW_1" qtlid="523268">Varsovie (WAW1) - Pologne</translation>
+   <translation id="server_usage_chart_yaxis_label">Utilisation (en %)</translation>
+   <translation id="server_usage_chart_xaxis_label">Temps</translation>
 </translations>


### PR DESCRIPTION
xAxis and yAxis labels are not shown correctly or missing in all RTM server usage graphs and CDN usage graphs

Closes MBE-347, MBP-392

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Title of the Pull Requests <!-- required -->
Real time monitoring, server usage graphs, invalid X and Y axis

### Description of the Change
CPU, Memory and SWAP usage graphs does no show valid data on x and y axis. I have added graph options to show proper percentage and time data. CDS usage graphs, bandwidth, requests and quota does not have y axis label. I have added it.

### Benefits

<!-- optional -->
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- optional -->
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues
MBE-347
