### PR TITLE
fix(deps): upgrade ovh-module-exchange to v9.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "ovh-api-services": "^6.1.2",
     "ovh-jquery-ui-draggable-ng": "^0.0.5",
     "ovh-manager-webfont": "^1.0.2",
-    "ovh-module-exchange": "^9.4.2",
+    "ovh-module-exchange": "^9.4.3",
     "ovh-ui-angular": "^2.29.1",
     "ovh-ui-kit": "^2.29.1",
     "ovh-ui-kit-bs": "~1.3.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7751,10 +7751,10 @@ ovh-manager-webfont@^1.0.2:
   resolved "https://registry.yarnpkg.com/ovh-manager-webfont/-/ovh-manager-webfont-1.0.2.tgz#8f9d358d138c2650a557bdac7a2d1908e962418d"
   integrity sha1-j501jROMJlClV72sei0ZCOliQY0=
 
-ovh-module-exchange@^9.4.2:
-  version "9.4.2"
-  resolved "https://registry.yarnpkg.com/ovh-module-exchange/-/ovh-module-exchange-9.4.2.tgz#0bf425aa514d86bb58a02e9a250a0ad3db9c2af0"
-  integrity sha512-KGMXV6RvpIb1HO08Lc9rZpKn9Re1iNhsHvNGDhX0+I9PNCu/tszZsT4yk3dodzIWkQbhP+OH2YWuUK10N9Zo1w==
+ovh-module-exchange@^9.4.3:
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/ovh-module-exchange/-/ovh-module-exchange-9.4.3.tgz#c303c5f0029555961b5a23564829b9686ed15464"
+  integrity sha512-7VwJNLlR8ckDj0MHca183GiSUnU6HSINYlYTpUhf5Rks7AYNeWFUwzy7WkO17mPyOonR3KG5NmhvurdSbLlIzw==
   dependencies:
     filesize "^3.6.1"
     lodash "~3.9.3"


### PR DESCRIPTION
# Upgrade ovh-module-exchange to v9.4.3

### :arrow_up: Upgrade

uses: yarn upgrade-interactive --latest
- ovh-module-exchange@9.4.3

### :house: Internal

- No QC required.