### PR TITLE
fix(license): add both windows server 2019 standard and datacenter

### DIFF
--- a/client/app/license/translations/Messages_fr_FR.xml
+++ b/client/app/license/translations/Messages_fr_FR.xml
@@ -362,6 +362,64 @@
    <translation id="license_designation_WINDOWS_version_windows-server-2016-license-standard-edition-4-cpu-22-cores" qtlid="373155">Microsoft Windows Server 2016 Standard Edition (4 CPU 22 CORES)</translation>
    <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2016_STANDARD_EDITION_4_CPU_24_CORES" qtlid="373168">Microsoft Windows Server 2016 Standard Edition (4 CPU 24 CORES)</translation>
    <translation id="license_designation_WINDOWS_version_windows-server-2016-license-standard-edition-4-cpu-24-cores" qtlid="373168">Microsoft Windows Server 2016 Standard Edition (4 CPU 24 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_8_CORES">Microsoft Windows Server 2019 Standard Edition (8 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_10_CORES">Microsoft Windows Server 2019 Standard Edition (10 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_12_CORES">Microsoft Windows Server 2019 Standard Edition (12 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_14_CORES">Microsoft Windows Server 2019 Standard Edition (14 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_16_CORES">Microsoft Windows Server 2019 Standard Edition (16 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_18_CORES">Microsoft Windows Server 2019 Standard Edition (18 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_20_CORES">Microsoft Windows Server 2019 Standard Edition (20 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_22_CORES">Microsoft Windows Server 2019 Standard Edition (22 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_24_CORES">Microsoft Windows Server 2019 Standard Edition (24 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_26_CORES">Microsoft Windows Server 2019 Standard Edition (26 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_28_CORES">Microsoft Windows Server 2019 Standard Edition (28 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_30_CORES">Microsoft Windows Server 2019 Standard Edition (30 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_32_CORES">Microsoft Windows Server 2019 Standard Edition (32 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_34_CORES">Microsoft Windows Server 2019 Standard Edition (34 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_36_CORES">Microsoft Windows Server 2019 Standard Edition (36 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_38_CORES">Microsoft Windows Server 2019 Standard Edition (38 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_40_CORES">Microsoft Windows Server 2019 Standard Edition (40 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_42_CORES">Microsoft Windows Server 2019 Standard Edition (42 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_44_CORES">Microsoft Windows Server 2019 Standard Edition (44 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_46_CORES">Microsoft Windows Server 2019 Standard Edition (46 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_48_CORES">Microsoft Windows Server 2019 Standard Edition (48 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_50_CORES">Microsoft Windows Server 2019 Standard Edition (50 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_52_CORES">Microsoft Windows Server 2019 Standard Edition (52 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_54_CORES">Microsoft Windows Server 2019 Standard Edition (54 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_56_CORES">Microsoft Windows Server 2019 Standard Edition (56 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_58_CORES">Microsoft Windows Server 2019 Standard Edition (58 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_60_CORES">Microsoft Windows Server 2019 Standard Edition (60 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_62_CORES">Microsoft Windows Server 2019 Standard Edition (62 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_STANDARD_EDITION_64_CORES">Microsoft Windows Server 2019 Standard Edition (64 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_8_CORES">Microsoft Windows Server 2019 Datacenter Edition (8 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_10_CORES">Microsoft Windows Server 2019 Datacenter Edition (10 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_12_CORES">Microsoft Windows Server 2019 Datacenter Edition (12 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_14_CORES">Microsoft Windows Server 2019 Datacenter Edition (14 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_16_CORES">Microsoft Windows Server 2019 Datacenter Edition (16 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_18_CORES">Microsoft Windows Server 2019 Datacenter Edition (18 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_20_CORES">Microsoft Windows Server 2019 Datacenter Edition (20 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_22_CORES">Microsoft Windows Server 2019 Datacenter Edition (22 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_24_CORES">Microsoft Windows Server 2019 Datacenter Edition (24 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_26_CORES">Microsoft Windows Server 2019 Datacenter Edition (26 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_28_CORES">Microsoft Windows Server 2019 Datacenter Edition (28 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_30_CORES">Microsoft Windows Server 2019 Datacenter Edition (30 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_32_CORES">Microsoft Windows Server 2019 Datacenter Edition (32 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_34_CORES">Microsoft Windows Server 2019 Datacenter Edition (34 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_36_CORES">Microsoft Windows Server 2019 Datacenter Edition (36 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_38_CORES">Microsoft Windows Server 2019 Datacenter Edition (38 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_40_CORES">Microsoft Windows Server 2019 Datacenter Edition (40 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_42_CORES">Microsoft Windows Server 2019 Datacenter Edition (42 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_44_CORES">Microsoft Windows Server 2019 Datacenter Edition (44 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_46_CORES">Microsoft Windows Server 2019 Datacenter Edition (46 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_48_CORES">Microsoft Windows Server 2019 Datacenter Edition (48 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_50_CORES">Microsoft Windows Server 2019 Datacenter Edition (50 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_52_CORES">Microsoft Windows Server 2019 Datacenter Edition (52 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_54_CORES">Microsoft Windows Server 2019 Datacenter Edition (54 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_56_CORES">Microsoft Windows Server 2019 Datacenter Edition (56 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_58_CORES">Microsoft Windows Server 2019 Datacenter Edition (58 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_60_CORES">Microsoft Windows Server 2019 Datacenter Edition (60 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_62_CORES">Microsoft Windows Server 2019 Datacenter Edition (62 CORES)</translation>
+   <translation id="license_designation_WINDOWS_version_WINDOWS_SERVER_2019_DATACENTER_EDITION_64_CORES">Microsoft Windows Server 2019 Datacenter Edition (64 CORES)</translation>
 
    <translation id="license_designation_WINDOWS_sql_version_SQL_SERVER_2008_STANDARD_EDITION" qtlid="162478">Microsoft SQL Server 2008 Standard Edition</translation>
    <translation id="license_designation_WINDOWS_sql_version_SQL_SERVER_2008_STANDARD_EDITION_2_CPU" qtlid="162491">Microsoft SQL Server 2008 Standard Edition (2 CPU)</translation>


### PR DESCRIPTION
# Add both windows server 2019 standard and datacenter

### :bug: Bug Fix

14483e0 - fix(license): add both windows server 2019 standard and datacenter

### :house: Internal

- No QC required.

ref: MBP-437