### PR TITLE
fix(account.billing): add missing translation on cancellation form

### DIFF
--- a/client/app/account/billing/translations/Messages_fr_FR.xml
+++ b/client/app/account/billing/translations/Messages_fr_FR.xml
@@ -144,6 +144,7 @@
    <translation id="autorenew_service_type_VEEAM_ENTERPRISE" qtlid="506362">Veeam Enterprise</translation>
    <translation id="autorenew_service_type_METRICS" qtlid="383525">Metrics</translation>
    <translation id="autorenew_service_type_kube" qtlid="504826">Kubernetes</translation>
+   <translation id="autorenew_service_type_cloud_project">Projet Cloud</translation>
 
 
    <translation id="autorenew_service_billing_warning" qtlid="229645">Vous n'avez pas le droit de modifier cette donnée</translation>


### PR DESCRIPTION
# Add missing translation on cancellation form

### :bug: Bug Fix

83fca10 - fix(account.billing): add missing translation on cancellation form

### :house: Internal

- No QC required.

ref: #1131 