### PR TITLE
fix(deps): upgrade manager-server-sidebar to 0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@ovh-ux/manager-config": "^0.2.0",
     "@ovh-ux/manager-core": "^5.2.5",
     "@ovh-ux/manager-navbar": "^0.5.0",
-    "@ovh-ux/manager-server-sidebar": "^0.1.5",
+    "@ovh-ux/manager-server-sidebar": "^0.1.6",
     "@ovh-ux/ng-at-internet": "^4.0.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^2.0.0",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -960,10 +960,10 @@
     lodash "^4.17.11"
     moment "^2.24.0"
 
-"@ovh-ux/manager-server-sidebar@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/manager-server-sidebar/-/manager-server-sidebar-0.1.5.tgz#33e3215eac2af8c22b8731da14a10a25e8e7687a"
-  integrity sha512-8RUZVcUgHXyO6JOz89aVbBTtLsSMaseMlhw5Cm0wgavYw71pKfvkJDkjVtLktw4BnUBx2OZm3gHMRLdT6uPnOA==
+"@ovh-ux/manager-server-sidebar@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/manager-server-sidebar/-/manager-server-sidebar-0.1.6.tgz#d991605fce17d21e509935e94cdd080a320d84c2"
+  integrity sha512-6oWUdzWLKkl3D3KHXad3F51YYX+NBxY+BpOhQ35VxRVhgmHQojBnJd7M7gkYTr+wwVoK8acfdNe2ZHl4nidRBw==
   dependencies:
     jsurl "^0.1.5"
     lodash "^4.17.11"


### PR DESCRIPTION
# Upgrade manager-server-sidebar to 0.1.6

### :arrow_up: Upgrade

uses: yarn upgrade-interactive --latest
- @ovh-ux/manager-server-sidebar@0.1.6

### :link: Related

- ovh-ux/manager#769