### PR TITLE
fix(deps): upgrade ng-ovh-otrs to v7.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@ovh-ux/ng-ovh-cloud-universe-components": "^1.3.0-alpha.4",
     "@ovh-ux/ng-ovh-contacts": "^1.0.1",
     "@ovh-ux/ng-ovh-http": "^4.0.1-beta.0",
-    "@ovh-ux/ng-ovh-otrs": "^7.1.0",
+    "@ovh-ux/ng-ovh-otrs": "^7.1.1",
     "@ovh-ux/ng-ovh-payment-method": "^2.0.0",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",
     "@ovh-ux/ng-ovh-responsive-popover": "^5.0.0-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1083,10 +1083,10 @@
     lodash "~4.17.11"
     urijs "^1.19.1"
 
-"@ovh-ux/ng-ovh-otrs@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-otrs/-/ng-ovh-otrs-7.1.0.tgz#52de74775afa5611b3ece9ba2a066aa0fa7bc959"
-  integrity sha512-fn4tWMFuddEn02DmVEj/+k9K3CgK2mPaDLAklq0xfUXGTMVg3j9GGQ1/wJbXpdmgXFqA2wQa39PP4JAQ6qagmA==
+"@ovh-ux/ng-ovh-otrs@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-otrs/-/ng-ovh-otrs-7.1.1.tgz#2c6ff776f26961b48c99202b6b7b87a6b37dc806"
+  integrity sha512-VfqZenH+8CnA7/SfGX4ZdqewGw7kr7zOS4j3ImiJsE2eLdyrxYH4tTy+5mqlolASi8Lo2b6t1odTx7Bvdtn/7Q==
   dependencies:
     draggable "^4.2.0"
     lodash "^4.17.11"


### PR DESCRIPTION
# Upgrade ng-ovh-otrs to v7.1.1

### :arrow_up: Upgrade

5ab3131 - fix(deps): upgrade ng-ovh-otrs to v7.1.1

uses: yarn upgrade-interactive --latest
- @ovh-ux/ng-ovh-otrs@7.1.1