### PR TITLE
feat(dedicated.server): remove useless information network tile

### DIFF
--- a/client/app/dedicated/server/dashboard/DASHBOARD_VIEW.html
+++ b/client/app/dedicated/server/dashboard/DASHBOARD_VIEW.html
@@ -551,15 +551,6 @@
                         <div class="oui-tile__item">
                             <dl class="oui-tile__definition">
                                 <dt class="oui-tile__term"
-                                    data-translate="server_bandwidth_ovh_to_ovh"></dt>
-                                <dd class="oui-tile__description"
-                                    data-ng-bind="bandwidth.bandwidth.OvhToOvh | ducBandwidth">
-                                </dd>
-                            </dl>
-                        </div>
-                        <div class="oui-tile__item">
-                            <dl class="oui-tile__definition">
-                                <dt class="oui-tile__term"
                                     data-translate="server_bandwidth_ovh_to_internet"></dt>
                                 <dd class="oui-tile__description">
                                     <span data-ng-bind="bandwidth.bandwidth.OvhToInternet | ducBandwidth"></span>


### PR DESCRIPTION
## Remove useless information


### Description of the Change

Remove information about bandwidth in order to avoid confusion

### References
MBP-473