### PR TITLE
fix(billing.autorenew): display alert only if autoRenew is not activated

### DIFF
--- a/client/app/account/billing/autoRenew/billing-autoRenew.html
+++ b/client/app/account/billing/autoRenew/billing-autoRenew.html
@@ -27,7 +27,7 @@
 
         <div class="alert alert-danger"
              role="alert"
-             data-ng-if="!automaticRenewV2Mean.loading && automaticRenewV2Mean.available && (!automaticRenewV2Mean.allowed || (automaticRenewV2Mean.allowed && !nicRenew.active)) && !services.data.userSubsidiaryHasRecentAutorenew">
+             data-ng-if="!automaticRenewV2Mean.loading && automaticRenewV2Mean.available && (!automaticRenewV2Mean.allowed || (automaticRenewV2Mean.allowed && !nicRenew.active && nicRenew.initialized)) && !services.data.userSubsidiaryHasRecentAutorenew">
             <button type="button"
                     class="close"
                     data-ng-click="automaticRenewV2Mean.noMeanMessageClose()"
@@ -35,7 +35,7 @@
                     data-dismiss="alert">
             </button>
             <p data-ng-if="!automaticRenewV2Mean.allowed" data-translate="autorenew_service_renew_requires_mean_and_date"></p>
-            <p data-ng-if="automaticRenewV2Mean.allowed && !nicRenew.active">
+            <p data-ng-if="automaticRenewV2Mean.allowed && !nicRenew.active && nicRenew.initialized">
                 <span data-translate="autorenew_service_activate_alert"></span>
                 <button class="btn btn-default"
                         type="button"


### PR DESCRIPTION
## fix(billing.autorenew): display alert only if autoRenew is not activated

### Description of the Change

45a50699 — fix(billing.autorenew): display alert only if autoRenew is not activated

ref: DTRUN-1949