### PR TITLE
fix(deps): upgrade ng-ovh-sidebar-menu to v8.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@ovh-ux/ng-ovh-payment-method": "^3.2.0",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",
     "@ovh-ux/ng-ovh-responsive-popover": "^5.0.0-beta.0",
-    "@ovh-ux/ng-ovh-sidebar-menu": "^8.3.2",
+    "@ovh-ux/ng-ovh-sidebar-menu": "^8.3.3",
     "@ovh-ux/ng-ovh-sso-auth": "^4.0.0",
     "@ovh-ux/ng-ovh-sso-auth-modal-plugin": "^3.0.0",
     "@ovh-ux/ng-ovh-swimming-poll": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1104,10 +1104,10 @@
     "@ovh-ux/translate-async-loader" "^1.0.0"
     jquery "^2.1.3"
 
-"@ovh-ux/ng-ovh-sidebar-menu@^8.3.2":
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-sidebar-menu/-/ng-ovh-sidebar-menu-8.3.2.tgz#e5b6451418ec7eb70660cf755a6f72d64bd7ac75"
-  integrity sha512-dJHMLgbHVVOL9vNbdfgMNpL/4W9g0jkfRSpWXeeMQVawIeLi181MMZu3FvTsS7RDjIcdzEF46jCmsk0X5Aq7dg==
+"@ovh-ux/ng-ovh-sidebar-menu@^8.3.3":
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-sidebar-menu/-/ng-ovh-sidebar-menu-8.3.3.tgz#6657271c7db6c7c0ae977ef844de115b976156ad"
+  integrity sha512-R0ZDnVZ9D29YwQytNvuRIgzIPr1iUbF3Luag4WSy6JGf+evEyyMmpZAgY9fCEvS9kPl0VlUtW+FVcwN8bxJ1yw==
 
 "@ovh-ux/ng-ovh-sso-auth-modal-plugin@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
# Upgrade ng-ovh-sidebar-menu to v8.3.3

## :arrow_up: Upgrade

uses: yarn upgrade-interactive --latest
- @ovh-ux/ng-ovh-sidebar-menu@8.3.3

## :link: Related

- ovh-ux/ng-ovh-sidebar-menu#75

## :house: Internal

ref: MBE-361
