### PR TITLE
build(deps): upgrade ovh-api-services to v7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "ovh-angular-responsive-tabs": "^4.0.0",
     "ovh-angular-tail-logs": "^1.1.1",
     "ovh-angular-toaster": "^0.8.0",
-    "ovh-api-services": "^6.32.0",
+    "ovh-api-services": "^7.0.0",
     "ovh-jquery-ui-draggable-ng": "^0.0.5",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-module-exchange": "^9.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8080,10 +8080,10 @@ ovh-angular-toaster@^0.8.0:
   resolved "https://registry.yarnpkg.com/ovh-angular-toaster/-/ovh-angular-toaster-0.8.0.tgz#7073201379ea196c721d583421c0cef1d04bdbdb"
   integrity sha1-cHMgE3nqGWxyHVg0IcDO8dBL29s=
 
-ovh-api-services@^6.32.0:
-  version "6.32.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-6.32.0.tgz#b3f9abe947224bfdf644586a52147d75971583b6"
-  integrity sha512-QFFTsOM6mjzUMIur96gXLm5IPw5OzL/DaQuEq03n7Y+zqP+rNvnvDZC65c1NMSKZfvkfJVigA/wcNxx6vk9jNg==
+ovh-api-services@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-7.0.0.tgz#240ced6f8930eed94b4484aa558ad8f432af537f"
+  integrity sha512-aC2NDo9Rf7iwJvfnoPJ2E9Rtrv7Yy7tNXFJv4PifBqyUefjbTAUCfDNRrxgVnpOmPJ1h5SWjx19t3T/6w8qVDw==
   dependencies:
     lodash "^3.10.1"
 


### PR DESCRIPTION
# Upgrade ovh-api-services to v7.0.0

## :arrow_up: Upgrade

uses: yarn upgrade-interactive --latest
- ovh-api-services@7.0.0

## :link: Related

- ovh-ux/ovh-api-services#191

## :house: Internal

- No QC required.