### PR TITLE
build: add __NG_APP_INJECTIONS__ to facilitate module injection

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
     "validator": true,
     "zE": true,
     "WEBPACK_ENV": true,
+    "__NG_APP_INJECTIONS__": true,
     "__WEBPACK_REGION__": true
   },
   "rules": {

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -30,6 +30,7 @@ Environment.setRegion(__WEBPACK_REGION__);
 
 angular
   .module('App', [
+    __NG_APP_INJECTIONS__,
     ovhManagerCore,
     'Billing',
     'chart.js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,6 +82,7 @@ module.exports = (env = {}) => {
     },
     plugins: [
       new webpack.DefinePlugin({
+        __NG_APP_INJECTIONS__: process.env.NG_APP_INJECTIONS ? `'${process.env.NG_APP_INJECTIONS}'` : 'null',
         __WEBPACK_REGION__: `'${env.region.toUpperCase()}'`,
       }),
     ],


### PR DESCRIPTION
# Add `__NG_APP_INJECTIONS__` to facilitate module injection

## ⚙️ Build

1a935a8 - build: add __NG_APP_INJECTIONS__ to facilitate module injection

## 🏠 Internal

- No QC required.