### PR TITLE
build(deps): upgrade ovh-api-services to v8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "ovh-angular-responsive-tabs": "^4.0.0",
     "ovh-angular-tail-logs": "^1.1.1",
     "ovh-angular-toaster": "^0.8.0",
-    "ovh-api-services": "^7.4.0",
+    "ovh-api-services": "^8.0.0",
     "ovh-jquery-ui-draggable-ng": "^0.0.5",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-module-exchange": "^9.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -710,7 +710,7 @@
   version "0.0.11"
   resolved "https://codeload.github.com/mareczek/international-phone-number/tar.gz/28055517d453a2f11e9035f2761243b6878df258"
 
-"@bower_components/lodash@lodash/lodash#~3.10.1", lodash@^3.10.1, lodash@lodash/lodash#~3.10.1, lodash@~3.10.0:
+"@bower_components/lodash@lodash/lodash#~3.10.1", lodash@lodash/lodash#~3.10.1, lodash@~3.10.0:
   version "3.10.1"
   resolved "https://codeload.github.com/lodash/lodash/tar.gz/dfbd78f71de0550068fc82ce6e013d443e5037d7"
 
@@ -6991,7 +6991,7 @@ lodash@^4.0.0, lodash@^4.11.1, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, 
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-lodash@^4.17.11:
+lodash@^4.17.11, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -8097,12 +8097,12 @@ ovh-angular-toaster@^0.8.0:
   resolved "https://registry.yarnpkg.com/ovh-angular-toaster/-/ovh-angular-toaster-0.8.0.tgz#7073201379ea196c721d583421c0cef1d04bdbdb"
   integrity sha1-cHMgE3nqGWxyHVg0IcDO8dBL29s=
 
-ovh-api-services@^7.4.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-7.4.0.tgz#a59affc5a5ebcff499f4d0a3cfb1f66e965c2ce6"
-  integrity sha512-Qmql4km9vqrAKobC0vpb05dPOYgmzH8BonhzX/KUfqmQBqrraVXwG+UdmMFZsgs38y4VmGWYoRWl7KrN5Shdyg==
+ovh-api-services@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-8.0.0.tgz#494d33d5896567e1d944f380931733f8ae4d18f5"
+  integrity sha512-1eO4z2+T4mWalDlSjwC/c4ZiG4YwFfky9jSbtVR4sRXWOowegJ5uhzlIR1tQocOjioNBsYpF17K2zxQRVVmwLw==
   dependencies:
-    lodash "^3.10.1"
+    lodash "^4.17.15"
 
 ovh-jquery-ui-draggable-ng@^0.0.5:
   version "0.0.5"


### PR DESCRIPTION
# Upgrade ovh-api-services to v8.0.0

## :arrow_up: Upgrade

uses: `yarn upgrade-interactive --latest`
- ovh-api-services@8.0.0

## :house: Internal

- No QC required.