### PR TITLE
build(deps): upgrade ng-ovh-http to v4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@ovh-ux/ng-ovh-chatbot": "^2.0.1",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^1.3.0-alpha.4",
     "@ovh-ux/ng-ovh-contacts": "^1.0.1",
-    "@ovh-ux/ng-ovh-http": "^4.0.1-beta.0",
+    "@ovh-ux/ng-ovh-http": "^4.0.2",
     "@ovh-ux/ng-ovh-otrs": "^7.1.7",
     "@ovh-ux/ng-ovh-payment-method": "^3.2.0",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1068,12 +1068,12 @@
   dependencies:
     lodash "^4.17.11"
 
-"@ovh-ux/ng-ovh-http@^4.0.1-beta.0":
-  version "4.0.1-beta.0"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-http/-/ng-ovh-http-4.0.1-beta.0.tgz#ccf793c7d34252952d0bf92d8f3a9ff2ca35e52e"
-  integrity sha512-D+pQvfzVr01fXlE75U2U3RdcxSBciqIo7CV4gJM5jyAS3zCXP4/YzNF/tCNIihNs9nI/juSieAnI7ah5xwVn+g==
+"@ovh-ux/ng-ovh-http@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-http/-/ng-ovh-http-4.0.2.tgz#4f4c38a7c8cca56ab018773d61bd6d83200d6293"
+  integrity sha512-7QKgJDUBGjYf0Ldr1Nk28lMRZc6jY3e7q+g3pZMyAlIp3kkzG8SZIGT+jnAO0YTyb0sb6bJEbiAQJ8TqGlE0ow==
   dependencies:
-    lodash "~4.17.11"
+    lodash "~4.17.15"
     urijs "^1.19.1"
 
 "@ovh-ux/ng-ovh-otrs@^7.1.7":
@@ -6991,7 +6991,7 @@ lodash@^4.0.0, lodash@^4.11.1, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, 
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-lodash@^4.17.11, lodash@^4.17.15:
+lodash@^4.17.11, lodash@^4.17.15, lodash@~4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
# Upgrade ng-ovh-http to v4.0.2

## :arrow_up: Upgrade

f3b774b - build(deps): upgrade ng-ovh-http to v4.0.2

uses: `yarn upgrade-interactive --latest`
- @ovh-ux/ng-ovh-http@4.0.2

## :house: Internal

- No QC required.