### PR TITLE
build(webpack): remove resolve.symlinks options

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,7 +77,6 @@ module.exports = (env = {}) => {
         jquery: path.resolve(__dirname, 'node_modules/jquery'),
       },
       mainFields: ['module', 'browser', 'main'],
-      symlinks: false,
     },
     plugins: [
       new webpack.DefinePlugin({


### PR DESCRIPTION
# Remove resolve.symlinks options

## :construction_worker_man: Build

93d22c7 - build(webpack): remove resolve.symlinks options

## :house: Internal

- No QC required.