### PR TITLE
fix(dedicated.servers): reset page number when filtering

### DIFF
--- a/client/app/dedicated/server/servers/servers.routing.js
+++ b/client/app/dedicated/server/servers/servers.routing.js
@@ -33,20 +33,26 @@ export default /* @ngInject */ ($stateProvider) => {
       filter: /* @ngInject */ $transition$ => $transition$.params().filter,
       orderUrl: /* @ngInject */ User => User.getUrlOf('dedicatedOrder'),
       getServerDashboardLink: /* @ngInject */ $state => server => $state.href('app.dedicated.server', { productId: server.name }),
-      dedicatedServers: /* @ngInject */ (iceberg, $stateParams) => {
-        const filters = JSON.parse($stateParams.filter);
-        let { page } = $stateParams;
+      dedicatedServers: /* @ngInject */ ($transition$, iceberg) => {
+        const {
+          filter,
+          pageSize,
+          sort,
+          sortOrder,
+        } = $transition$.params();
+        let { page } = $transition$.params();
+        const filtersParsed = JSON.parse(filter);
 
-        if (filters.length > 0) {
+        if (filtersParsed.length > 0) {
           page = 1;
         }
 
         let request = iceberg('/dedicated/server')
           .query()
           .expand('CachedObjectList-Pages')
-          .limit($stateParams.pageSize)
+          .limit(pageSize)
           .offset(page)
-          .sort($stateParams.sort, $stateParams.sortOrder);
+          .sort(sort, sortOrder);
 
         const FILTER_OPERATORS = {
           contains: 'like',
@@ -60,7 +66,7 @@ export default /* @ngInject */ ($stateProvider) => {
           endsWith: 'like',
         };
 
-        filters.forEach(({ field, comparator, reference }) => {
+        filtersParsed.forEach(({ field, comparator, reference }) => {
           request = request.addFilter(
             field,
             _.get(FILTER_OPERATORS, comparator),

--- a/client/app/dedicated/server/servers/servers.routing.js
+++ b/client/app/dedicated/server/servers/servers.routing.js
@@ -35,11 +35,17 @@ export default /* @ngInject */ ($stateProvider) => {
       getServerDashboardLink: /* @ngInject */ $state => server => $state.href('app.dedicated.server', { productId: server.name }),
       dedicatedServers: /* @ngInject */ (iceberg, $stateParams) => {
         const filters = JSON.parse($stateParams.filter);
+        let { page } = $stateParams;
+
+        if (filters.length > 0) {
+          page = 1;
+        }
+
         let request = iceberg('/dedicated/server')
           .query()
           .expand('CachedObjectList-Pages')
           .limit($stateParams.pageSize)
-          .offset($stateParams.page)
+          .offset(page)
           .sort($stateParams.sort, $stateParams.sortOrder);
 
         const FILTER_OPERATORS = {


### PR DESCRIPTION
## Dedicated servers list filter issue

### Description of the Change

Switching page doesn't filter properly. Force set page 1.
