### PR TITLE
fix(deps): upgrade ovh-module-exchange to v9.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "ovh-api-services": "^9.8.0",
     "ovh-jquery-ui-draggable-ng": "^0.0.5",
     "ovh-manager-webfont": "^1.2.0",
-    "ovh-module-exchange": "^9.4.7",
+    "ovh-module-exchange": "^9.4.8",
     "ovh-ui-angular": "^3.7.6",
     "ovh-ui-kit": "^2.33.4",
     "ovh-ui-kit-bs": "~1.3.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8159,10 +8159,10 @@ ovh-manager-webfont@^1.2.0:
   resolved "https://registry.yarnpkg.com/ovh-manager-webfont/-/ovh-manager-webfont-1.2.0.tgz#e59e89e6248b7bf97b204bb18521b2f5bd347961"
   integrity sha512-J2ticTEGQEKbiE0NpI8yaiGmVFrbyllonUHcIsfgaEhY1gl9cug0ktiJGTc40sVFwlygsNYoM360xZvJkeX7lw==
 
-ovh-module-exchange@^9.4.7:
-  version "9.4.7"
-  resolved "https://registry.yarnpkg.com/ovh-module-exchange/-/ovh-module-exchange-9.4.7.tgz#2d60d6bbb164f6a6290a1e0d08585731488dbf95"
-  integrity sha512-B+XKrcF6qVySRJgb2I1mXy38MzoLBZ9rOiYdljFElsOOxD48zIPZXtcergGJ+EnMsDSzC2/7L1g92iM80Rfk6Q==
+ovh-module-exchange@^9.4.8:
+  version "9.4.8"
+  resolved "https://registry.yarnpkg.com/ovh-module-exchange/-/ovh-module-exchange-9.4.8.tgz#4a65b6a0fa380fbb55604a66f327ffb3292feb08"
+  integrity sha512-8/lGc2PjXHsLeXKPpBPhglbfPV2LjCVGQ1vwxE+ASGGY78JKMFWMFucoRv6/ec88BG/etkH8bA4nqutLrJaYGQ==
   dependencies:
     filesize "^3.6.1"
     lodash "~3.9.3"


### PR DESCRIPTION
# Upgrade ovh-module-exchange to v9.4.8

## :arrow_up: Upgrade

e06e784 - fix(deps): upgrade ovh-module-exchange to v9.4.8

uses: `yarn upgrade-interactive --latest ovh-module-exchange`
- ovh-module-exchange@9.4.8

## :house: Internal

- No quality check required.
