### PR TITLE
fix(account.contacts.service): post to the right URL

### DIFF
--- a/client/app/account/contacts/service/contacts-service.service.js
+++ b/client/app/account/contacts/service/contacts-service.service.js
@@ -17,7 +17,7 @@ export default class {
   }
 
   changeContact(service) {
-    return this.OvhHttp.post(`${service.path}/${service.serviceName}/changeContact'`, {
+    return this.OvhHttp.post(`${service.path}/${service.serviceName}/changeContact`, {
       rootPath: 'apiv6',
       data: {
         contactAdmin: service.contactAdmin,


### PR DESCRIPTION
# Post to the right URL

Remove extra `'` sign at the end of the URL.

## 🚑 Hotfix

3fc7f22 - fix(account.contacts.service): post to the right URL

## 🏠 Internal

ref: DTRUN-3788