### PR TITLE
fix(deps): upgrade manager-server-sidebar to v0.6.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@ovh-ux/manager-core": "^7.1.2",
     "@ovh-ux/manager-enterprise-cloud-database": "^0.1.0",
     "@ovh-ux/manager-navbar": "^2.0.3",
-    "@ovh-ux/manager-server-sidebar": "^0.6.3",
+    "@ovh-ux/manager-server-sidebar": "^0.6.7",
     "@ovh-ux/ng-at-internet": "^4.0.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^2.0.0",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,10 +939,10 @@
     lodash "^4.17.15"
     moment "^2.24.0"
 
-"@ovh-ux/manager-server-sidebar@^0.6.3":
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/manager-server-sidebar/-/manager-server-sidebar-0.6.3.tgz#3ccbea8a9e41b24be978311bdd20030fb591119a"
-  integrity sha512-wiExLchTd2TrHNUw1FMvOemxy7lUtj1H+AZ51by3DlmqSCi3/5P7TrGfcxWhSk+Cpu4dFq0+S+NoO8ZdE6GQ1g==
+"@ovh-ux/manager-server-sidebar@^0.6.7":
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/manager-server-sidebar/-/manager-server-sidebar-0.6.7.tgz#0738345b0f482a15d6527a8b68dace2c442151f7"
+  integrity sha512-qmzKVtunf/JuKt50mGzRe3SmOY7Zeg/9S26GuSm3ohj/3LwXgJYPnv/E9mPClfO1E0CACpgE+D7gbXrleMbzgQ==
   dependencies:
     font-awesome "~4.7.0"
     jsurl "^0.1.5"


### PR DESCRIPTION
# Upgrade manager-server-sidebar to v0.6.7

## :ambulance: Hotfix

22ea728 - fix(deps): upgrade manager-server-sidebar to v0.6.7

## :link: Related

- ovh/manager#1492

ref: MANAGER-3819
