### PR TITLE
fix: update getter to get function

### DIFF
--- a/client/app/billing/autoRenew/disable/disable.controller.js
+++ b/client/app/billing/autoRenew/disable/disable.controller.js
@@ -6,7 +6,7 @@ export default class {
 
   $onInit() {
     this.descriptions = {
-      getSingleUpdate: service => this.$translate.instant('billing_autorenew_disable_bulk_single', { serviceName: service.serviceName }),
+      getSingleUpdate: service => this.$translate.instant('billing_autorenew_disable_bulk_single', { serviceName: service.getServiceName() }),
       getCompleteUpdate: () => this.$translate.instant('billing_autorenew_disable_bulk'),
       getUncompleteUpdate: count => (count === 1 ? this.$translate.instant('billing_autorenew_disable_bulk_unavailable_one') : this.$translate.instant('billing_autorenew_disable_bulk_unavailable', { count })),
     };

--- a/client/app/billing/autoRenew/enable/enable.controller.js
+++ b/client/app/billing/autoRenew/enable/enable.controller.js
@@ -6,7 +6,7 @@ export default class {
 
   $onInit() {
     this.descriptions = {
-      getSingleUpdate: service => this.$translate.instant('billing_autorenew_enable_bulk_single', { serviceName: service.serviceName }),
+      getSingleUpdate: service => this.$translate.instant('billing_autorenew_enable_bulk_single', { serviceName: service.getServiceName() }),
       getCompleteUpdate: () => this.$translate.instant('billing_autorenew_enable_bulk'),
       getUncompleteUpdate: count => (count === 1 ? this.$translate.instant('billing_autorenew_enable_bulk_unavailable_one') : this.$translate.instant('billing_autorenew_enable_bulk_unavailable', { count })),
     };

--- a/client/app/models/BillingService.class.js
+++ b/client/app/models/BillingService.class.js
@@ -8,7 +8,7 @@ export default class BillingService {
     this.expirationDate = moment(this.expiration);
   }
 
-  get serviceName() {
+  getServiceName() {
     return this.serviceId;
   }
 


### PR DESCRIPTION
Issue brought by MANAGER-3756

Payloads are inconsistent and some services can have a serviceName, in that case the object cannot be constructed and the getter will override the default value