### PR TITLE
fix(deps): upgrade @ovh-ux/ng-ovh-otrs to v7.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@ovh-ux/ng-ovh-contacts": "^1.0.1",
     "@ovh-ux/ng-ovh-contracts": "^3.0.0",
     "@ovh-ux/ng-ovh-http": "^4.0.2",
-    "@ovh-ux/ng-ovh-otrs": "7.1.11",
+    "@ovh-ux/ng-ovh-otrs": "7.1.12",
     "@ovh-ux/ng-ovh-payment-method": "^5.0.0",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",
     "@ovh-ux/ng-ovh-request-tagger": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1070,10 +1070,10 @@
     lodash "~4.17.15"
     urijs "^1.19.1"
 
-"@ovh-ux/ng-ovh-otrs@7.1.11":
-  version "7.1.11"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-otrs/-/ng-ovh-otrs-7.1.11.tgz#39fec6c9f6cdf8cb4c292e8ed4dca759c4cd1acf"
-  integrity sha512-vZzTWZZkVfEuNrAuBNRjZB+4MCdTDaB4qMpLuQy6l5TrflJLrx4H9qzt5DcpEvNWwTzXVMfuOwq+qHrkJQKfwg==
+"@ovh-ux/ng-ovh-otrs@7.1.12":
+  version "7.1.12"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-otrs/-/ng-ovh-otrs-7.1.12.tgz#37fc3e1dd1905d6dc6dd035ed118f36267006721"
+  integrity sha512-8EHexcBl8I49yd6Wr7CT1N55Lczuxjbfnp1bVeA7MVoDuhxmlz1+8ieQHjZAeJW/wKmZ3wxS2n5LIoNsgtDdaw==
   dependencies:
     draggable "^4.2.0"
     lodash "^4.17.11"


### PR DESCRIPTION
# Upgrade @ovh-ux/ng-ovh-otrs to v7.1.12

## :ambulance: Hotfix

e11a996 - fix(deps): upgrade @ovh-ux/ng-ovh-otrs to v7.1.12

uses: `yarn upgrade-interactive --latest @ovh-ux/ng-ovh-otrs`
- @ovh-ux/ng-ovh-otrs@7.1.12

## :link: Related

- ovh-ux/ng-ovh-otrs#124

## :house: Internal

- ref: MANAGER-3890

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>
